### PR TITLE
Added Apache Ranger migration section. Did a bit of re-organizing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This guide is open for anyone to make changes and suggest new content. If there 
 This repo uses mkdocs and is hosted on Github. To get started and creating content, the easiest way is to use [poetry](https://python-poetry.org/). The following commands should get you started:
 * You can install poetry using ```brew install poetry``` if you are running on MacOS. If you are using a different OS, please see the [installation instructions](https://python-poetry.org/docs/#installation) for your OS.
 * ```poetry install``` that will create a virtual python environment and install the necessary dependencies.
-* To run the local version of mkdocs and to preview changes in real-time, run ```poetry shell``` and once in the virtual environment, run ```mkdocs serve```. 
+* To run the local version of mkdocs and to preview changes in real-time, run ```poetry run mkdocs serve```. 
 * Make your changes, preferably on a branch for large updates.
 * Create a Github pull request with your changes to be reviewed and merged.
 

--- a/content/adopting-lake-formation/overview.md
+++ b/content/adopting-lake-formation/overview.md
@@ -1,7 +1,57 @@
-# Adopting Lake Formation Best Practices
+# Adopting Lake Formation
 
-To successfuly adopt Lake Formation, there are many different considerations that need to be taken. This section will go over some of the key areas, with best practices, on how to adopt Lake Formation.
+AWS Lake Formation centralizes permissions management for your data lake, enabling fine-grained access control over databases, tables, and columns registered in the AWS Glue Data Catalog. This section covers everything you need to plan and execute a Lake Formation adoption — from initial evaluation through migration.
 
-* See [Considerations when adopting Lake Formation](considerations-when-adopting-lake-formation.md) for a non-exhaustive list of areas that will need to be looked at the beginning of adopting Lake Formation. 
-* See [General best practices](general-best-practices.md) for high level best practices when configuring Lake Formation.
-* See [Lake Formation adoption modes](lake-formation-adoption-modes.md) for looking into Lake Formations Hybrid Access Mode.
+---
+
+## Before You Start
+
+[Considerations when adopting Lake Formation](considerations-when-adopting-lake-formation.md) walks through a structured evaluation checklist covering:
+
+- Taking inventory of your data stores and analytics engines
+- Reviewing your current access management model
+- Choosing a permissions model (named-resource vs. LF-Tags)
+- Understanding identity integration options (IAM, IAM Identity Center, Trusted Identity Propagation)
+- Deciding on account topology and cross-account sharing
+
+This is the recommended starting point if you are evaluating Lake Formation for the first time.
+
+---
+
+## Adoption Modes
+
+[Lake Formation Adoption Modes](lake-formation-adoption-modes.md) explains the two modes for registering S3 locations with Lake Formation and when to use each:
+
+- **Lake Formation mode** — Lake Formation is the sole permissions model for governed resources. Recommended for greenfield environments or teams with minimal existing IAM-based access.
+- **Hybrid access mode** — Lake Formation and IAM resource-based policies coexist on the same resources. Individual principals can be opted in to Lake Formation while others continue using IAM without interruption. Recommended when existing workloads cannot be migrated all at once.
+
+Understanding adoption modes is a prerequisite for choosing a migration approach.
+
+---
+
+## Migrating to Lake Formation
+
+The right migration path depends on where you are starting from:
+
+| Current Permission Model | Guide |
+|--------------------------|-------|
+| IAM and S3 bucket policies (AWS-native) | [Lake Formation Transition Guide — Single Account](transition-guide/lake-formation-transition-guide-single-account.md) |
+| Apache Ranger (Hadoop / on-premises) | [Migrating from Apache Ranger](transition-guide/apache-ranger-to-lake-formation.md) |
+
+### Transition guides
+
+- **[Lake Formation Transition Guide — Single Account](transition-guide/lake-formation-transition-guide-single-account.md)** — two incremental migration plans for environments already on AWS. Both are reversible and designed for production environments with active consumers.
+  - [Plan #1 — Per Resource Transition](transition-guide/single-account-transition-plan-1-per-resource.md): migrate table by table; all consumers of a resource move at once.
+  - [Plan #2 — Per User Transition](transition-guide/single-account-transition-plan-2-per-user.md): migrate user by user using Hybrid access mode opt-ins; surgical rollback per user.
+
+- **[Migrating from Apache Ranger](transition-guide/apache-ranger-to-lake-formation.md)** — covers policy model translation, handling Ranger deny/except semantics, tag-based access control mapping, security zone equivalents, and LDAP/AD to IAM identity mapping.
+
+---
+
+## General Best Practices
+
+[General Best Practices](general-best-practices.md) covers configuration recommendations that apply regardless of migration path:
+
+- Using a customer-managed IAM role for data location registration instead of the Lake Formation Service Linked Role
+- Scoping Lake Formation Administrator access appropriately
+- When to use Data Filters vs. Glue Views for row and column filtering

--- a/content/adopting-lake-formation/transition-guide/apache-ranger-to-lake-formation.md
+++ b/content/adopting-lake-formation/transition-guide/apache-ranger-to-lake-formation.md
@@ -61,19 +61,27 @@ This model lets administrators write broad allow rules and carve out specific ex
 
 **Lake Formation has no deny mechanism.** Grants are purely additive. The effective permissions for a principal are the union of all grants that reference that principal. There is no way to subtract a permission once granted.
 
-### Worked example
+### Worked examples
 
-**Ranger policy:** Allow group "analysts" SELECT on table `customers`, all columns. Exclude from allow: group "analysts" on column `customers.ssn`.
+#### Example 1 - exclude tables ####
 
-**Lake Formation equivalent:** Grant SELECT on table `customers`, listing every column *except* `ssn` explicitly to the IAM role or Identity Center group representing "analysts."
+**Ranger policy:** Allow group "analysts" SELECT on all tables in the `customers` database, with exclude table `customer_info`. 
 
-This works but introduces a maintenance cost: any new column added to `customers` must be explicitly added to the grant. In Ranger, the wildcard allow plus column-level exclude handled this automatically.
+**Lake Formation equivalent:** Grant SELECT on all tables within Glue Data Catalog in the `customers`, except on the `customer_info` table. 
+
+This works but introduces a maintenance cost: any new table added to the `customers` database must be explicitly added. 
+
+#### Example 2 - exclude columns ####
+
+**Ranger policy:** Allow group "analysts" SELECT on columns in the `customers_info` database, with exclude on column `ssn`. 
+
+**Lake Formation equivalent:** Grant SELECT for group "analysts" to the `customers_info` table, with the "exclude columns" of the `ssn` column.
 
 ### Workarounds by pattern
 
 | Ranger pattern | Lake Formation approach |
 |----------------|------------------------|
-| Allow all columns, deny specific columns | Grant SELECT on included columns only (explicit column list). Update grants when schema changes. |
+| Allow all columns, deny specific columns | Grant SELECT on excluded columns (explicit column list). |
 | Allow all users, deny specific users | Do not grant the excluded users. Since grants are additive, omission is the equivalent of denial. |
 | Allow a group, exclude a subgroup | Create separate IAM roles or Identity Center groups that reflect the split. Grant only to the permitted subset. |
 | Row-level deny (deny rows matching a filter) | Use data filters with `RowFilter` expressions that return only permitted rows. Invert the deny condition into an allow condition. |

--- a/content/adopting-lake-formation/transition-guide/apache-ranger-to-lake-formation.md
+++ b/content/adopting-lake-formation/transition-guide/apache-ranger-to-lake-formation.md
@@ -1,0 +1,225 @@
+# Migrating from Apache Ranger to Lake Formation
+
+Organizations running Apache Hadoop clusters often rely on Apache Ranger to manage fine-grained access control over data stored in HDFS, Hive Metastore, and related services. As these organizations migrate analytics workloads to AWS, they encounter AWS Lake Formation, which provides column-level and row-level permissions for data in Amazon S3 registered through the AWS Glue Data Catalog.
+
+Ranger and Lake Formation solve the same core problem — controlling who can read which tables, columns, and rows — but they differ in architecture, policy model, and identity integration. A Ranger policy cannot be copied into Lake Formation unchanged.
+
+This guide covers:
+
+- [The structural differences between Ranger and Lake Formation](#differences-between-apache-ranger-and-lake-formation)
+- [Catalog migration (HMS to Glue Data Catalog)](#hive-metastore-vs-glue-data-catalog)
+- [Handling deny and except policies](#deny-and-except-policies)
+- [Tag-based access control translation](#tag-based-access-control)
+- [Security zones and multi-tenancy](#security-zones)
+- [Identity mapping from LDAP/AD to IAM](#identity-mapping)
+- [HDFS to S3](#hdfs-to-s3)
+
+> **Note:** This guide covers the access-control layer only. It does not cover migrating data itself (ETL pipelines, schema conversion, S3 layout).
+
+---
+
+## Differences Between Apache Ranger and Lake Formation
+
+Apache Ranger and AWS Lake Formation both govern access to analytical data, but they differ in where enforcement happens, how policies are expressed, and what identity systems they consume.
+
+| Dimension | Apache Ranger | AWS Lake Formation |
+|-----------|---------------|-------------------|
+| **Policy model** | Allow, deny, and exceptions. Deny takes precedence over allow. | Grant-only. No deny grants exist. Permissions are additive; the union of all grants determines effective access. |
+| **Permission granularity** | Database, table, column, row-level (row-filter policies), and cell-level (column masking + row filter). | Database, table, column, row-level (data filters), and cell-level (column + row filter combined in a data filter). |
+| **Catalog system** | Hive Metastore (HMS). | AWS Glue Data Catalog (GDC). All governed resources must exist in GDC. |
+| **Identity integration** | LDAP, Active Directory, Kerberos principals, OS users/groups. | IAM principals (roles, users), IAM Identity Center users/groups, and AWS Organizations. |
+| **Tag-based access control** | Atlas-sourced or Ranger-native tags. A single tag policy covers all resources sharing that tag across services. | LF-Tags (key-value pairs) assigned to databases, tables, and columns in GDC. Boolean expressions over tag keys in a single grant. |
+| **Multi-tenancy / security zones** | Security zones partition the resource namespace with delegated administrators per zone. | No direct equivalent. Isolation is achieved through separate AWS accounts, IAM role delegation with grantable permissions, or distinct LF-Tag taxonomies. |
+| **Auditing** | Ranger audit logs in Solr or HDFS. Each access decision recorded with user, resource, policy ID, and timestamp. | AWS CloudTrail logs Lake Formation API calls and data access events for each vended credential. |
+| **Enforcement point** | Plugin-per-service model. Each service (Hive, Spark, HBase, HDFS) loads a Ranger plugin that evaluates policies locally. | Centralized. Lake Formation vends temporary credentials scoped to the granted permissions. S3 enforces access via those scoped credentials. |
+
+---
+
+## Hive Metastore vs. Glue Data Catalog
+
+Apache Ranger can enforce policies against resources in either a Hive Metastore or the AWS Glue Data Catalog. Lake Formation operates exclusively against the Glue Data Catalog. Every database, table, and column that Lake Formation governs must exist in GDC.
+
+This creates a hard dependency in migration sequencing: **catalog migration to GDC must complete before policy translation can begin.** Ranger policies reference catalog resources by name (database, table, column). If those resources do not yet exist in GDC, there is nothing for a Lake Formation grant to bind to.
+
+For detailed steps on migrating Hive Metastore metadata into the Glue Data Catalog, refer to the [HMS to Glue Data Catalog migration guide](https://aws.highspot.com/items/6a284d07987cca17721d8f59).
+
+### Migration action
+
+Complete the Hive Metastore to Glue Data Catalog migration before beginning policy translation. Validate that all databases, tables, and partitions referenced by existing Ranger policies are present in GDC. Any resource missing from GDC will be an orphaned policy with no equivalent grant target in Lake Formation.
+
+---
+
+## Deny and Except Policies
+
+Apache Ranger evaluates access decisions using a three-layer model: allow policies, deny policies, and exceptions to each. When a request arrives, Ranger checks:
+
+1. Is there a **deny policy** that matches this user and resource? If yes, deny — unless the user falls under an exception to that deny (an "exclude from deny" entry).
+2. Is there an **allow policy** that matches? If yes, allow — unless the user falls under an exception to that allow (an "exclude from allow" entry).
+3. If no policy matches, deny by default.
+
+This model lets administrators write broad allow rules and carve out specific exclusions without enumerating every permitted user. For example: "All analysts can query the `customers` table, except the `ssn` column" is a single allow policy on `customers.*` with an exclude-from-allow on `customers.ssn`.
+
+**Lake Formation has no deny mechanism.** Grants are purely additive. The effective permissions for a principal are the union of all grants that reference that principal. There is no way to subtract a permission once granted.
+
+### Worked example
+
+**Ranger policy:** Allow group "analysts" SELECT on table `customers`, all columns. Exclude from allow: group "analysts" on column `customers.ssn`.
+
+**Lake Formation equivalent:** Grant SELECT on table `customers`, listing every column *except* `ssn` explicitly to the IAM role or Identity Center group representing "analysts."
+
+This works but introduces a maintenance cost: any new column added to `customers` must be explicitly added to the grant. In Ranger, the wildcard allow plus column-level exclude handled this automatically.
+
+### Workarounds by pattern
+
+| Ranger pattern | Lake Formation approach |
+|----------------|------------------------|
+| Allow all columns, deny specific columns | Grant SELECT on included columns only (explicit column list). Update grants when schema changes. |
+| Allow all users, deny specific users | Do not grant the excluded users. Since grants are additive, omission is the equivalent of denial. |
+| Allow a group, exclude a subgroup | Create separate IAM roles or Identity Center groups that reflect the split. Grant only to the permitted subset. |
+| Row-level deny (deny rows matching a filter) | Use data filters with `RowFilter` expressions that return only permitted rows. Invert the deny condition into an allow condition. |
+
+### Patterns with no clean equivalent
+
+- **Priority-ordered deny:** In Ranger, a deny policy with higher priority overrides a lower-priority allow. Lake Formation has no policy priority concept. The union of all grants determines access.
+- **Dynamic exclusion:** Ranger deny policies can use runtime attributes (request context, time-of-day via custom conditions) to deny access dynamically. Lake Formation grants are static.
+- **Cross-table deny with wildcards:** A single Ranger deny policy can reference multiple tables using wildcards (e.g., deny group "interns" access to all tables matching `*_pii`). Lake Formation grants are per-resource; use LF-Tags to approximate wildcard coverage across tables.
+
+### Migration action
+
+Inventory all Ranger deny and exclude-from-allow policies. For each one, determine whether the equivalent restriction can be achieved by narrowing the corresponding Lake Formation grant (granting only the permitted subset). Where the deny pattern relies on wildcards, priority ordering, or runtime conditions, the access model will need restructuring — typically by splitting principals into more granular groups or restructuring table layouts to separate sensitive columns into distinct tables.
+
+---
+
+## Tag-Based Access Control
+
+Apache Ranger supports tag-based policies through integration with Apache Atlas (or Ranger's own tag service). Atlas classifies resources (tables, columns) with tags such as "PII", "CONFIDENTIAL", or "FINANCE". Ranger policies then reference these tags rather than specific resource names. A single tag policy controls access to every resource carrying a given tag, regardless of which database or table it belongs to. Ranger tag policies follow the same allow/deny/exception model as resource policies.
+
+AWS Lake Formation provides **LF-Tags**: key-value pairs assigned to databases, tables, and columns in the Glue Data Catalog. Permissions are granted using tag expressions (e.g., grant SELECT to a principal on all resources where `sensitivity=high` AND `domain=finance`). LF-Tags support inheritance: a tag assigned to a database propagates to all tables and columns within it unless overridden at a lower level.
+
+### Key differences
+
+| Aspect | Ranger (Atlas tags) | Lake Formation (LF-Tags) |
+|--------|---------------------|--------------------------|
+| **Tag source** | Apache Atlas classification, or Ranger native tag service | Assigned directly in Glue Data Catalog via LF API |
+| **Tag structure** | Flat classification names (e.g., "PII"), optionally with attributes | Key-value pairs (e.g., `sensitivity=high`) with enumerated allowed values per key |
+| **Policy model on tags** | Allow, deny, and exceptions on tagged resources | Grant-only on tag expressions (no deny) |
+| **Scope** | Cross-service (Hive, HBase, HDFS, Kafka; any Atlas-classified resource) | Glue Data Catalog resources only (databases, tables, columns) |
+| **Inheritance** | Determined by Atlas lineage and propagation rules | Hierarchical: database → table → column, with override at each level |
+| **Compound expressions** | One tag per policy; multiple policies combine via evaluation order | Boolean AND expressions over multiple tag keys in a single grant |
+
+### Migration steps
+
+1. **Inventory Atlas tags in use.** Extract all tag classifications referenced by Ranger tag policies. Map each to an LF-Tag key-value pair. Flat classifications like "PII" become a key-value such as `sensitivity=PII` or `classification=PII`.
+
+2. **Define the LF-Tag taxonomy.** LF-Tags require predefined keys and allowed values. Unlike Atlas, where any string can be a tag, LF-Tag values must be enumerated upfront. Plan the taxonomy before assigning tags.
+
+3. **Assign LF-Tags to catalog resources.** For each resource that carried an Atlas tag, apply the corresponding LF-Tag in GDC. Use inheritance (tag the database) where the tag applies uniformly; override at the table or column level where exceptions exist.
+
+4. **Translate tag policies to LF-Tag grants.** Each Ranger tag-allow policy becomes a Lake Formation tag-based grant. Where Ranger tag-deny policies exist, the same constraints from the [deny/except section](#deny-and-except-policies) apply: denial must be restructured as omission from the grant or separation of principals.
+
+5. **Account for scope reduction.** Ranger tag policies may cover non-catalog resources (HDFS paths, Kafka topics, HBase tables). These are outside Lake Formation's scope. Access control for those resources must be handled separately (S3 bucket policies, MSK IAM auth, or other AWS-native mechanisms).
+
+---
+
+## Security Zones
+
+Apache Ranger security zones partition the resource namespace into isolated administrative domains. Each zone defines a set of resources (specific databases, tables, or path prefixes) and assigns zone-level administrators who can create and manage policies only within their zone's boundary. A resource belongs to exactly one zone.
+
+This model supports multi-tenant Hadoop environments where separate teams manage their own access policies without interfering with each other.
+
+**Lake Formation has no direct equivalent to security zones.** There is no built-in mechanism to partition the Glue Data Catalog into named administrative scopes within a single AWS account.
+
+### Achieving similar isolation
+
+| Ranger security zone pattern | Lake Formation approach |
+|------------------------------|------------------------|
+| Zone per business unit with delegated admin | Create an IAM role per zone. Grant that role grantable permissions (`GRANT OPTION`) on the specific databases and tables belonging to that zone. The role can administer access within its delegated resources without affecting resources outside its scope. |
+| Zone scoped to specific databases | Grant grantable permissions on those databases and tables to the zone-admin role. That role can grant downstream access to other principals, but only on resources it holds grantable permissions for. |
+| Hard trust boundaries between zones | Separate AWS accounts per boundary. Each account has its own Glue Data Catalog and Lake Formation administrators. Cross-account resource links provide controlled sharing where needed. |
+
+### Migration action
+
+Inventory all Ranger security zones and the resources assigned to each. For each zone, create a corresponding IAM role to serve as the zone administrator. Grant that role grantable permissions on the zone's resources in Lake Formation. Principals who previously administered policies within a Ranger zone now assume the corresponding IAM role to manage grants within their delegated scope.
+
+Where zones represent hard trust boundaries — teams that must not be able to affect each other's access under any circumstance — use separate AWS accounts rather than role-based delegation within a single account.
+
+---
+
+## Identity Mapping
+
+Apache Ranger policies bind to identities sourced from external directory services. In a typical Hadoop deployment, Ranger resolves users and groups from LDAP, Active Directory, or Unix/OS-level user stores, with Kerberos providing authentication. A Ranger policy might grant access to `group:data-engineers` or `user:jsmith`, where those names correspond to entries in the connected directory.
+
+Lake Formation grants bind to AWS identity primitives:
+
+- **IAM users and roles:** grants reference ARNs (e.g., `arn:aws:iam::123456789012:role/analytics-role`)
+- **IAM Identity Center users and groups:** grants reference Identity Center ARNs
+- **AWS Organizations:** grants can target an entire organization or organizational unit for cross-account sharing
+
+The identity that Lake Formation evaluates depends on how the environment is configured. In the default model, Lake Formation authorizes based on the IAM principal (role or user) making the API call. When **Trusted Identity Propagation (TIP)** is enabled, Lake Formation authorizes based on the IAM Identity Center user identity instead — the actual end-user identity is passed through the query engine to Lake Formation, bypassing the IAM role as the authorization subject.
+
+### Key differences
+
+| Aspect | Apache Ranger | Lake Formation |
+|--------|---------------|----------------|
+| **Identity source** | LDAP, Active Directory, Unix users, Kerberos principals | IAM roles/users, IAM Identity Center |
+| **Group model** | Directory groups (nested groups supported depending on directory) | IAM Identity Center groups, or implicit grouping via shared IAM roles |
+| **Policy binding** | Username or group name string match | IAM principal ARN (default), or Identity Center user/group identity (with Trusted Identity Propagation) |
+| **Authentication** | Kerberos (typically), or delegated to the service | AWS SigV4 (IAM credentials or Identity Center session) |
+| **User-to-principal mapping** | 1:1 — user authenticates as themselves | Many-to-one possible when using IAM roles; 1:1 when using TIP with Identity Center |
+
+### Migration action
+
+Map every Ranger user and group referenced in existing policies to an AWS identity. The approach depends on the organization's identity strategy:
+
+1. **Identity Center with Trusted Identity Propagation (recommended for named-user mapping):** Sync the existing LDAP/AD directory to IAM Identity Center via SCIM or AD Connector. Users and groups retain their names in Identity Center. Enable Trusted Identity Propagation so Lake Formation authorizes based on the Identity Center identity directly. This preserves the per-user, per-group access model from Ranger most closely.
+
+2. **IAM roles per functional group:** Where organizations use role-based access (all analysts assume an "analyst" role), create IAM roles corresponding to each Ranger group. Grant Lake Formation permissions to those roles. Users authenticate via Identity Center and assume the appropriate role.
+
+3. **Handling unmapped identities:** Ranger policies referencing service accounts, OS-level users, or Kerberos principals with no corresponding AWS identity require new IAM roles or Identity Center accounts to be provisioned. These often represent service-to-service access that translates to IAM role trust policies rather than Lake Formation grants.
+
+Extract the full list of users and groups from Ranger's UserSync or the underlying directory. Cross-reference against the set of principals that will exist in AWS post-migration. Any gap — a Ranger identity with no AWS equivalent — must be resolved before policies can be translated.
+
+---
+
+## HDFS to S3
+
+Apache Ranger provides path-level access control for HDFS. Ranger HDFS policies grant or deny read, write, and execute permissions on directory paths (e.g., allow group "etl-team" write access to `/data/warehouse/finance/`). These policies operate at the storage layer, independent of any catalog or table abstraction.
+
+AWS Lake Formation does not govern storage-path access. Lake Formation permissions apply only to catalog resources (databases, tables, columns) registered in the Glue Data Catalog. When a workload accesses S3 directly by path rather than through a catalog-aware query engine, Lake Formation is not involved in the authorization decision.
+
+For organizations that relied on Ranger HDFS policies to control who can read or write specific S3-prefixed paths, **Amazon S3 Access Grants** fills this gap.
+
+S3 Access Grants provide location-based grants that map S3 prefixes to IAM or Identity Center identities. An S3 Access Grants instance defines locations (S3 prefixes such as `s3://my-bucket/finance/`) and grants access to those locations for specific principals at a defined permission level (READ, WRITE, or READWRITE).
+
+### Comparison
+
+| Aspect | Ranger HDFS policies | S3 Access Grants |
+|--------|---------------------|-----------------|
+| **Target** | HDFS directory paths | S3 bucket prefixes |
+| **Permissions** | Read, write, execute (with deny/exception support) | READ, WRITE, READWRITE (grant-only, no deny) |
+| **Identity** | LDAP/AD users and groups | IAM principals or IAM Identity Center users/groups |
+| **Granularity** | Any path depth in HDFS | Any prefix depth in S3 |
+| **Scope** | Per-cluster (each cluster has its own Ranger) | Per S3 Access Grants instance (can span multiple buckets within a region) |
+| **Integration with catalog permissions** | Independent of Hive/Ranger resource policies (complementary layer) | Independent of Lake Formation catalog grants (complementary layer) |
+
+### Migration guidance
+
+1. **Inventory Ranger HDFS policies.** Extract all path-based policies and the principals they reference. Identify which HDFS paths correspond to S3 locations in the migrated environment.
+
+2. **Map HDFS paths to S3 prefixes.** For each HDFS path governed by a Ranger policy, determine the equivalent S3 prefix in the target architecture. Example: `/data/warehouse/finance/` becomes `s3://datalake-bucket/warehouse/finance/`.
+
+3. **Create an S3 Access Grants instance.** Register the S3 locations (prefixes) that need path-level access control. Associate the instance with an Identity Center instance if using named-user grants.
+
+4. **Translate Ranger HDFS grants to S3 Access Grants.** Each Ranger HDFS allow policy becomes an S3 Access Grant at the corresponding prefix. Since S3 Access Grants has no deny model, the same constraints from the deny/except section apply: restrict access by granting only the permitted subset of principals.
+
+5. **Complement Lake Formation with S3 Access Grants.** Use Lake Formation for catalog-level permissions (table/column/row access) and S3 Access Grants for storage-level permissions (direct path access). The two systems are complementary: Lake Formation governs query engines reading through the Glue Data Catalog, while S3 Access Grants governs direct S3 API access to the underlying data files.
+
+---
+
+## How to Get Help
+
+- **AWS Lake Formation documentation** at [docs.aws.amazon.com/lake-formation](https://docs.aws.amazon.com/lake-formation/) covers grant management, LF-Tags, data filters, Trusted Identity Propagation, and cross-account sharing.
+- **AWS Prescriptive Guidance:** Published migration patterns and architecture recommendations for analytics workloads moving to AWS-native services.
+- **AWS Solutions Architects:** Customers with an AWS account team can engage their Solutions Architect for architecture reviews of their migration plan, particularly for complex deny-policy translation and multi-account design.
+- **AWS re:Post:** Community Q&A for specific implementation questions related to Lake Formation permissions and Glue Data Catalog configuration.
+- **AWS Support:** For customers with Business or Enterprise support plans, support cases can be opened for Lake Formation configuration and troubleshooting.

--- a/content/adopting-lake-formation/transition-guide/lake-formation-transition-guide-single-account.md
+++ b/content/adopting-lake-formation/transition-guide/lake-formation-transition-guide-single-account.md
@@ -1,0 +1,314 @@
+# Lake Formation Transition Guide — Single Account Migrations
+
+## Overview
+
+Many organizations start their data lake journey with IAM policies and S3 bucket policies controlling access to data. As the environment grows — more tables, more consumers, more teams — managing access through IAM alone becomes increasingly complex and error-prone. AWS Lake Formation simplifies this by providing a centralized permissions model that sits on top of the AWS Glue Data Catalog: you grant access to databases, tables, and columns directly, and Lake Formation vends temporary credentials to authorized principals.
+
+The challenge is not adopting Lake Formation — it's transitioning to it without disrupting existing workloads. A production environment with active consumers cannot simply "flip a switch." The transition needs to be incremental, reversible, and low-risk.
+
+### What You Should Know Before Starting
+
+* Lake Formation metadata permissions are safe to set up at any time. Granting LF permissions on databases, tables, and columns is a no-op until IAMAllowedPrincipals is removed and S3 locations are registered for credential vending. You can begin layering in LF permissions well before "flipping the switch."
+* S3 bucket policies still apply. Lake Formation credential vending controls access to data through temporary credentials — it does not modify or replace your S3 bucket policies.
+* The transition is incremental. You do not need to migrate everything at once. Both plans in this guide are designed for step-by-step migration with validation at each stage.
+
+### What This Guide Covers
+
+This guide presents two approaches to transitioning a single AWS account to Lake Formation credential vending. Plan #1 (Per Resource) migrates table by table — all consumers of a resource move together. Plan #2 (Per User) migrates user by user — individual principals are opted in while others remain on IAM. Both approaches are reversible, and guidance is provided on when to use each.
+
+---
+
+## Prerequisites (Both Plans)
+
+Before starting either transition plan:
+
+1. **Designate a Lake Formation Administrator** — At minimum, one IAM principal must be registered as an LF Admin. Optionally, designate database-level administrators for delegation.
+2. **Add `lakeformation:GetDataAccess` to all consumer IAM policies** — This permission is required for credential vending. It is a **no-op** when no locations are registered, so it is safe (and recommended) to add upfront for all principals. This eliminates a class of errors during migration.
+3. **Enable CloudTrail for Glue Data Catalog events** — Management events (on by default) capture `GetTable`, `GetPartitions`, `BatchGetPartition`, `CreateTable`, etc. These are essential for identifying consumers.
+4. **Identify service roles** — Services like Redshift Spectrum, EMR, and Athena use service/execution roles. These roles are treated the same as user roles — they need LF grants and `lakeformation:GetDataAccess`.
+5. **Decide on a permissions model** — Choose between named-resource permissions or LF-Tags (tag-based access control). This decision affects how you grant permissions but does not change the migration mechanics.
+
+---
+
+## Transition Plans
+
+### Plan #1 — Per Resource Transition
+
+Migrate **table by table** (or location by location). For each resource, all consumers are migrated at once. This is a clean "all or nothing" approach per resource.
+
+- Register S3 locations with full registration
+- Grant LF permissions to all consumers of a table before activating credential vending
+- Rollback by deregistering the location (affects all consumers of that table)
+
+👉 [Full details: Transition Plan #1 — Per Resource](single-account-transition-plan-1-per-resource.md)
+
+### Plan #2 — Per User Transition
+
+Migrate **user by user** (or cohort by cohort). Hybrid access mode allows you to opt individual principals into Lake Formation credential vending while others continue using IAM.
+
+- Register S3 locations in Hybrid mode
+- Use `CreateLakeFormationOptIn` to flip individual users to LF
+- Rollback by removing the opt-in for a specific user (surgical, no impact to others)
+
+👉 [Full details: Transition Plan #2 — Per User](single-account-transition-plan-2-per-user.md)
+
+---
+
+## When to Use Plan #1 vs Plan #2
+
+| | **Plan #1 — Per Resource** | **Plan #2 — Per User** |
+|---|---|---|
+| **Best for** | Environments with many tables but few consumers per table; simpler IAM structures | Environments with many users accessing overlapping tables; complex orgs needing controlled rollout |
+| **Pros** | Simpler — no Hybrid mode needed; clean "all or nothing" per table; easier to reason about completion | Granular control — migrate users at their own pace; lower risk per change; can pilot with a single team; allows rollback per user (remove opt-in) |
+| **Cons** | If a table has many consumers, all must be ready simultaneously; harder to do partial rollback (deregister affects everyone); blocked by the "busiest" consumer | More complex orchestration; Hybrid mode + opt-in tracking required; must handle "shared table" conflicts (two users in different cohorts accessing same table); longer tail to full completion |
+| **Rollback** | Deregister location (affects all consumers of that table) | Remove opt-in for specific user (surgical) |
+| **Prerequisite complexity** | Must identify all consumers per table upfront | Must identify all tables per user upfront |
+| **When it breaks down** | Tables with hundreds of consumers across many teams | Users who access hundreds of tables across many databases |
+
+> **Tip:** Many real-world migrations combine both approaches — use Plan #2 for complex, high-traffic tables (migrate users incrementally) and Plan #1 for the long tail of rarely-used tables (migrate them in bulk).
+
+---
+
+## How Do You Find Out Who Is Consuming What?
+
+Two complementary approaches:
+
+### 1. CloudTrail Management Events (Recommended Starting Point)
+
+Query CloudTrail for Glue Data Catalog API calls:
+- `GetTable`, `GetTables`
+- `GetPartitions`, `BatchGetPartition`
+- `GetDatabase`
+- `CreateTable`, `UpdateTable` (for identifying writers)
+
+For each table, extract:
+- The list of principals (IAM roles/users) accessing it
+- Access frequency (helps prioritize)
+- The table's S3 location
+
+This tells you **who is actively accessing** each table.
+
+??? note "Click to expand sample Athena Query for Lake Formation permissions from CloudTrail"
+    ```sql
+        WITH cloudtrail as (
+            SELECT *,
+                CASE
+                    WHEN eventname in ('CreateDatabase', 'GetDatabases') THEN 'CATALOG'
+                    WHEN eventname in (
+                        'GetDatabase',
+                        'UpdateDatabase',
+                        'DeleteDatabase',
+                        'CreateTable',
+                        'GetTables'
+                    ) THEN 'DATABASE'
+                    WHEN eventname in (
+                        'GetTable',
+                        'GetTableVersion',
+                        'GetTableVersions',
+                        'GetPartition',
+                        'GetUnfilteredPartition',
+                        'GetInternalUnfilteredPartition',
+                        'GetInternalUnfilteredPartitions',
+                        'GetPartitions',
+                        'GetUnfilteredPartitions',
+                        'BatchGetPartition',
+                        'GetPartitionIndexes',
+                        'UpdateTable',
+                        'DeleteTableVersion',
+                        'BatchDeleteTableVersion',
+                        'BatchCreatePartition',
+                        'CreatePartition',
+                        'DeletePartition',
+                        'BatchDeletePartition',
+                        'UpdatePartition',
+                        'BatchUpdatePartition',
+                        'CreatePartitionIndex',
+                        'DeletePartitionIndex',
+                        'DeleteTable'
+                    ) THEN 'TABLE'
+                END as resource_level
+            FROM <INSERT CLOUDTRAIL TABLE HERE>
+            WHERE eventsource = 'glue.amazonaws.com'
+                and eventname in (
+                    'GetDatabase',
+                    'GetDatabases',
+                    'UpdateDatabase',
+                    'DeleteDatabase',
+                    'CreateTable',
+                    'CreateDatabase',
+                    'GetTable',
+                    'GetTables',
+                    'GetTableVersion',
+                    'GetTableVersions',
+                    'GetPartition',
+                    'GetUnfilteredPartition',
+                    'GetInternalUnfilteredPartition',
+                    'GetInternalUnfilteredPartitions',
+                    'GetPartitions',
+                    'GetUnfilteredPartitions',
+                    'BatchGetPartition',
+                    'GetPartitionIndexes',
+                    'UpdateTable',
+                    'DeleteTableVersion',
+                    'BatchDeleteTableVersion',
+                    'BatchCreatePartition',
+                    'CreatePartition',
+                    'DeletePartition',
+                    'BatchDeletePartition',
+                    'UpdatePartition',
+                    'BatchUpdatePartition',
+                    'CreatePartitionIndex',
+                    'DeletePartitionIndex',
+                    'DeleteTable'
+                )
+                and errorcode IS NULL -- We only support these useridentity types for now
+                and useridentity.type in ('IAMUser', 'AssumedRole')
+        )
+        SELECT CASE
+                WHEN useridentity.type = 'IAMUser' THEN useridentity.arn
+                WHEN useridentity.type = 'AssumedRole' THEN useridentity.sessioncontext.sessionissuer.arn ELSE NULL
+            END as user_arn,
+            eventname,
+            -- the following translation is not used, rather we use GlueDataCatalogActionTranslator instead.
+            CASE
+                -- Database level permissions
+                WHEN eventname in ('GetDatabase') THEN 'DESCRIBE'
+                WHEN eventname in ('UpdateDatabase') THEN 'ALTER'
+                WHEN eventname in ('DeleteDatabase') THEN 'DROP'
+                WHEN eventname in ('CreateTable') THEN 'CREATE_TABLE'
+                WHEN eventname in ('CreateDatabase') THEN 'CREATE_DATABASE' -- These action have no permission requirements.
+                -- WHEN eventname in ('GetDatabases') THEN 'LIST_DBS'
+                WHEN eventname in ('GetTables') THEN 'DESCRIBE' -- Table Level permissions
+                WHEN eventname in (
+                    'GetTable',
+                    'GetTableVersion',
+                    'GetTableVersions',
+                    'GetPartition',
+                    'GetUnfilteredPartition',
+                    'GetInternalUnfilteredPartition',
+                    'GetInternalUnfilteredPartitions',
+                    'GetPartitions',
+                    'GetUnfilteredPartitions',
+                    'BatchGetPartition',
+                    'GetPartitionIndexes'
+                ) THEN 'DESCRIBE'
+                WHEN eventname in (
+                    'UpdateTable',
+                    'DeleteTableVersion',
+                    'BatchDeleteTableVersion',
+                    'BatchCreatePartition',
+                    'CreatePartition',
+                    'DeletePartition',
+                    'BatchDeletePartition',
+                    'UpdatePartition',
+                    'BatchUpdatePartition',
+                    'CreatePartitionIndex',
+                    'DeletePartitionIndex'
+                ) THEN 'ALTER'
+                WHEN eventname in ('DeleteTable') THEN 'DROP' ELSE 'UNKNOWN'
+            END as permission,
+            resource_level,
+            awsRegion,
+            CASE
+                WHEN json_extract_scalar(requestparameters, '$.catalogId') IS NOT NULL THEN json_extract_scalar(requestparameters, '$.catalogId') ELSE useridentity.accountid
+            END as aws_account_id,
+            CASE
+                WHEN resource_level = 'DATABASE' THEN CASE
+                    WHEN eventname in ('GetTables', 'CreateTable') THEN json_extract_scalar(requestparameters, '$.databaseName') ELSE json_extract_scalar(requestparameters, '$.name')
+                END
+                WHEN eventname = 'CreateDatabase' THEN json_extract_scalar(requestparameters, '$.databaseInput.name') ELSE json_extract_scalar(requestparameters, '$.databaseName')
+            END as database_name,
+            CASE
+                WHEN resource_level = 'TABLE' THEN CASE
+                    WHEN json_extract_scalar(requestparameters, '$.tableName') IS NULL THEN json_extract_scalar(requestparameters, '$.name') ELSE json_extract_scalar(requestparameters, '$.tableName')
+                END
+                WHEN eventname = 'CreateTable' THEN json_extract_scalar(requestparameters, '$.tableInput.name')
+            END as table_name,
+            SUM(1) as count
+        FROM cloudtrail
+        GROUP BY 1,2,3,4,5,6,7,8
+    ```
+
+
+??? note "Click to expand sample code to extract table locations"
+    ```python
+    import boto3
+    import csv
+    import sys
+
+    glue = boto3.client('glue')
+
+    writer = csv.writer(sys.stdout)
+    writer.writerow(['catalog_id', 'database_name', 'table_name', 's3_location'])
+
+    paginator = glue.get_paginator('get_databases')
+    for db_page in paginator.paginate():
+        for db in db_page['DatabaseList']:
+            db_name = db['Name']
+            catalog_id = db.get('CatalogId', '')
+
+            table_paginator = glue.get_paginator('get_tables')
+            for table_page in table_paginator.paginate(DatabaseName=db_name):
+                for table in table_page['TableList']:
+                    table_name = table['Name']
+                    location = table.get('StorageDescriptor', {}).get('Location', '')
+                    writer.writerow([catalog_id, db_name, table_name, location])
+    ```
+
+### 2. Policy Analysis
+
+Parse existing IAM and resource policies:
+- S3 bucket policies
+- IAM role/user policies
+- Glue Resource Policies
+
+This tells you **who *could* access** the data (may be broader than active users — includes dormant permissions).
+
+**Tool:** Use [policy-migrator-for-lake-formation](https://github.com/awslabs/policy-migrator-for-lake-formation) in **dry-run mode** to generate LF grants based on existing policies. This is complementary to CloudTrail analysis — it catches permissions that aren't actively exercised. 
+
+---
+
+## Best Practices & Considerations
+
+### Batch by S3 Location, Not Just by Table
+
+Multiple tables can share an S3 prefix. When you register a location, **all tables under that path** get credential vending at once. Always check what other tables exist under a path before registering — you may need to prepare grants for tables you hadn't planned to migrate yet.
+
+### Add `lakeformation:GetDataAccess` Upfront
+
+This is the single most effective thing you can do before starting either plan. It's a no-op without registered locations, so there is zero risk. Adding it to all principals at the start eliminates the most common migration error: "user can't access data because they're missing the IAM permission for credential vending."
+
+### Service Roles Are Principals Too
+
+Services like Redshift Spectrum, EMR, Athena, and Glue ETL use execution/service roles. These roles need:
+- LF grants (just like user roles)
+- `lakeformation:GetDataAccess` in their IAM policy
+- Data Location Permissions (if they write data)
+
+Don't forget to include these in your consumer analysis.
+
+### Tracking Progress (Plan #2)
+
+As you scale to many users and tables, maintain a manifest tracking:
+- Which locations are registered (and in what mode)
+- Which users are opted in for which resources
+- Use `ListLakeFormationOptIns` API to audit progress
+
+### New Users During Migration (Plan #2)
+
+For locations already in Hybrid mode, **opt in new users immediately** rather than letting them start on IAM. This prevents growing the migration backlog and ensures new users are already on the target state.
+
+---
+
+## Completion Checklist
+
+Once migration is complete (either plan), verify:
+
+- [ ] All S3 data locations are registered (full registration, not Hybrid)
+- [ ] IAMAllowedPrincipals removed from **all** databases and tables
+- [ ] Direct S3 data access removed from consumer IAM policies (for migrated paths)
+- [ ] Data Location Permissions granted for all write/create-table locations
+- [ ] No Glue Resource Policies granting open catalog access remain
+- [ ] All service roles (EMR, Redshift, Athena, Glue ETL) have LF grants
+- [ ] `lakeformation:GetDataAccess` confirmed on all consumer IAM policies
+- [ ] CloudTrail shows no access failures for a defined bake period (7–14 days recommended)

--- a/content/adopting-lake-formation/transition-guide/single-account-transition-plan-1-per-resource.md
+++ b/content/adopting-lake-formation/transition-guide/single-account-transition-plan-1-per-resource.md
@@ -1,0 +1,88 @@
+# Transition Plan #1 — Per Resource Transition
+
+In this approach, you migrate **table by table** (or location by location). For each resource, all consumers are migrated at once. This is a clean "all or nothing" approach **per resource**.
+
+## Flow Diagram
+
+??? note "Click to expand flow diagram"
+
+    ```mermaid
+    flowchart TD
+        A[Identify consumers per table via CloudTrail] --> B[Prioritize tables: fewest consumers first]
+        B --> C[Select next table/location to migrate]
+        
+        C --> D[Grant LF table/column permissions to all consumers of selected tables]
+        D --> E[Grant CREATE_TABLE + DESCRIBE on database if first table in DB]
+        E --> F[Grant Data Location Permissions to table creators]
+        F --> G[Register S3 location full registration]
+        G --> H{Validate: Can all consumers access data?}
+        
+        H -->|Yes| I[Remove IAMAllowedPrincipals from table]
+        H -->|No| R1[Rollback: Deregister location]
+        R1 --> R2[Diagnose & fix LF grants]
+        R2 --> G
+        
+        I --> J{All tables in this database migrated?}
+        J -->|Yes| K[Remove IAMAllowedPrincipals from database and uncheck auto-creation]
+        J -->|No| C
+        K --> L{All databases migrated?}
+        L -->|No| C
+        L -->|Yes| M[Remove direct S3 access for migrated paths from IAM policies]
+        M --> N[Clean up Glue Resource Policies]
+        N --> O[Migration Complete]
+    ```
+
+## Steps
+
+### Step 1 — Identify Consumers Per Table
+
+Determine who is accessing each table and how frequently. See [How Do You Find Out Who Is Consuming What?](lake-formation-transition-guide-single-account.md#how-do-you-find-out-who-is-consuming-what) in the overview.
+
+### Step 2 — Prioritize Tables
+
+- Start with tables that have the **fewest consumers** — these have the smallest blast radius.
+- Adjust for business priority: you may choose to migrate high-priority or high-risk tables with low usage early.
+- **Important:** Group tables by S3 location. When you register an S3 path, *all* tables under that path get credential vending simultaneously. Plan your batches around S3 prefixes to avoid accidentally migrating tables you're not ready for.
+
+### Step 3 — For Each Table (or batch of tables sharing a location):
+
+| Step | Action |
+|------|--------|
+| 3a | Grant LF **table/column permissions** to all identified consumers |
+| 3b | Grant `CREATE_TABLE` + `DESCRIBE` on the **database** to principals who need it (if this is the first table in that database being migrated) |
+| 3c | Grant **Data Location Permissions** to any users who write data or create tables at that S3 path |
+| 3d | **Register the S3 location** (full registration). This activates credential vending for all tables under this path. |
+| 3e | **Validate** — confirm all consumers can read/write as expected |
+| 3f | **Remove IAMAllowedPrincipals** from the table |
+
+### Step 4 — Database Cleanup
+
+Once all tables in a database have been migrated, remove IAMAllowedPrincipals from the database itself and uncheck "Use only IAM access control for new tables in this database" in database properties. If any new tables were created, their IAMAllowedPrincipals would need to be revoked as well. 
+
+### Step 5 — Final Cleanup
+
+Once all databases are migrated:
+- Remove direct S3 data access (for Glue table paths) from consumer IAM policies or S3 Bucket policies. They are no longer needed.
+- Remove any Glue Resource Policies that granted open catalog access
+- Uncheck "Use only IAM access control for new tables in new databases" and "Use only IAM access control for new databases" in Data Catalog settings in the Lake Formation console.
+
+## Rollback — Plan #1
+
+??? note "Click to expand rollback diagram"
+
+    ```mermaid
+    flowchart TD
+        A[Consumer loses access after registration] --> B{Has IAMAllowedPrincipals been removed?}
+        B -->|No| C[Deregister the S3 location]
+        C --> D[Access reverts to IAM-based]
+        D --> E[Diagnose: missing LF grant? missing Data Location Permission?]
+        E --> F[Fix LF grants]
+        F --> G[Re-register location]
+        G --> H[Re-validate]
+        
+        B -->|Yes| I[Re-add IAMAllowedPrincipals to table/database]
+        I --> J[Deregister the S3 location]
+        J --> D
+    ```
+
+**Key principle:** Do NOT remove IAMAllowedPrincipals until you have validated access post-registration. Registration + validation is your safety net — keep IAMAllowedPrincipals in place until you're confident.

--- a/content/adopting-lake-formation/transition-guide/single-account-transition-plan-2-per-user.md
+++ b/content/adopting-lake-formation/transition-guide/single-account-transition-plan-2-per-user.md
@@ -1,0 +1,120 @@
+# Transition Plan #2 — Per User Transition
+
+In this approach, you migrate **user by user** (or cohort by cohort). Hybrid access mode allows you to opt individual principals into Lake Formation credential vending while others continue using IAM. This gives you surgical control and per-user rollback.
+
+## Flow Diagram
+
+??? note "Click to expand flow diagram"
+
+    ```mermaid
+    flowchart TD
+        A[Select a cohort of users] --> B[Look up tables they access via CloudTrail]
+        B --> C[Identify if users create tables and where]
+        C --> D[Grant Data Location Permissions for write paths]
+        D --> E[Grant CREATE_TABLE on relevant databases]
+        E --> F[Grant LF table/column permissions to cohort users]
+        
+        F --> G{Are table S3 locations already registered as Hybrid?}
+        G -->|No| H[Register S3 locations as Hybrid]
+        G -->|Yes| I[Skip — already registered]
+        H --> I
+        
+        I --> J[Create LakeFormation Opt-In for each user + resource]
+        J --> K{Validate: queries work? CREATE TABLE works?}
+        
+        K -->|Yes| L{More cohorts to migrate?}
+        K -->|No| R1[Remove Opt-In for affected user]
+        R1 --> R2[Diagnose & fix]
+        R2 --> J
+        
+        L -->|Yes| A
+        L -->|No| M[All users opted in for all locations]
+        M --> N[Convert Hybrid locations to full registration]
+        N --> O[Remove IAMAllowedPrincipals from tables and databases]
+        O --> P[Remove direct S3 access from IAM policies]
+        P --> Q[Migration Complete]
+    ```
+
+## Decision Tree — New Users During Migration
+
+??? note "Click to expand decision tree"
+
+    ```mermaid
+    flowchart TD
+        A[New user needs table access] --> B{Is the table's location in Hybrid mode?}
+        B -->|No| C[User uses IAM as normal — not yet migrated]
+        B -->|Yes| D{Is this user part of a migration cohort?}
+        D -->|Yes| E[Grant LF permissions + Opt-In immediately]
+        D -->|No| F[Recommended: Opt-in new users immediately to avoid growing backlog]
+    ```
+
+## Steps
+
+### Step 1 — Select a Cohort
+
+Choose a group of users to migrate. Good candidates for the first cohort:
+- Users with limited table access (small blast radius)
+- A single team that owns their own data
+- Power users who can help validate quickly
+
+### Step 2 — Identify Table Access and Write Patterns
+
+- Look up all tables the cohort accesses (CloudTrail `GetTable`, `GetPartitions`, etc.)
+- Check if these users **create tables** — look for `CreateTable`, `UpdateTable` calls
+- Note the S3 paths where they create tables
+
+### Step 3 — Grant Permissions
+
+| Step | Action |
+|------|--------|
+| 3a | Grant **Data Location Permissions** for S3 paths where users write/create tables. If tables location is a prefix of the database's location, you can ignore this step as the permission is implicitly applied. |
+| 3b | Grant `CREATE_TABLE` permission in LF on relevant databases |
+| 3c | Grant LF **table/column permissions** to the cohort's users for all their tables |
+| 3d | Ensure `lakeformation:GetDataAccess` is in their IAM policies (should already be done in prerequisites) |
+
+### Step 4 — Register and Opt-In
+
+- Register the tables' S3 locations as **Hybrid Access Mode** locations (if not already registered)
+  - Hybrid Access Mode means: non-opted-in users continue on IAM, opted-in users use LF credential vending
+- **Create LakeFormation Opt-In** (`CreateLakeFormationOptIn`) for each user + resource combination
+  - This is the step that "flips" the user to LF where IAMAllowedPrincipal permission is ignore, and credential vending is enabled (if data lake location is registered)
+- Keep IAMAllowedPrincipals **enabled** on databases — do not put databases in Hybrid mode (adds complexity with no value)
+
+> **Note:** Location registration is a one-time step. If a location was registered as Hybrid during a previous cohort's migration, you only need to grant LF permissions and create opt-ins for the new cohort.
+
+### Step 5 — Validate
+
+- Run representative queries as the opted-in users
+- Verify `CREATE TABLE` works for users who create tables
+- Confirm that **non-opted-in users are unaffected** (still using IAM)
+- If issues arise → remove the opt-in (see Rollback below)
+
+### Step 6 — Repeat
+
+Select the next cohort and repeat Steps 1–5.
+
+### Step 7 — Completion
+
+Once ALL users of a given location are opted in:
+1. Convert from Hybrid to **full registration** (remove Hybrid flag)
+2. Remove IAMAllowedPrincipals from tables and databases
+3. Remove direct S3 access (for Glue table paths) from consumer IAM policies
+
+**"Done" signal:** When `ListLakeFormationOptIns` shows all known consumers are opted in AND CloudTrail shows no non-opted-in access for a defined period (e.g., 7–14 days), you can safely convert to full registration.
+
+## Rollback — Plan #2
+
+??? note "Click to expand rollback diagram"
+
+    ```mermaid
+    flowchart TD
+        A[User loses access after opt-in] --> B[Remove Opt-In: DeleteLakeFormationOptIn]
+        B --> C[User immediately reverts to IAM-based access]
+        C --> D[No impact to other users]
+        D --> E[Diagnose: missing LF grant? Data Location Permission? CREATE_TABLE?]
+        E --> F[Fix permissions]
+        F --> G[Re-create Opt-In]
+        G --> H[Re-validate]
+    ```
+
+**Key advantage:** Rollback is surgical. Removing an opt-in only affects that specific user — no other users or resources are impacted.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,8 +15,14 @@ nav:
   - 'Adopting Lake Formation':
     - 'Overview': 'adopting-lake-formation/overview.md'
     - 'Considerations when adopting Lake Formation': 'adopting-lake-formation/considerations-when-adopting-lake-formation.md'
-    - 'Lake formation Adoption Modes': 'adopting-lake-formation/lake-formation-adoption-modes.md'
+    - 'Lake Formation Adoption Modes': 'adopting-lake-formation/lake-formation-adoption-modes.md'
     - 'General Best Practices': 'adopting-lake-formation/general-best-practices.md'
+    - 'Migrating to Lake Formation':
+      - 'From IAM/S3 Policies — Single Account':
+        - 'Overview': 'adopting-lake-formation/transition-guide/lake-formation-transition-guide-single-account.md'
+        - 'Plan #1 — Per Resource Transition': 'adopting-lake-formation/transition-guide/single-account-transition-plan-1-per-resource.md'
+        - 'Plan #2 — Per User Transition': 'adopting-lake-formation/transition-guide/single-account-transition-plan-2-per-user.md'
+      - 'From Apache Ranger': 'adopting-lake-formation/transition-guide/apache-ranger-to-lake-formation.md'
   - 'Data Sharing':
     - 'Overview': 'data-sharing/overview.md'
     - 'General Best Practices when using Lake Formation Data Sharing': 'data-sharing/general-data-sharing.md'
@@ -35,6 +41,7 @@ markdown_extensions:
   - toc:
       permalink: true
   - admonition
+  - pymdownx.details
   - codehilite
   - pymdownx.highlight:
       anchor_linenums: true
@@ -42,17 +49,11 @@ markdown_extensions:
       pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
-  - attr_list
-  - sane_lists
-  - tables
-  - pymdownx.highlight:
-      anchor_linenums: true
-      line_spans: __span
-      pygments_lang_class: true
-  - pymdownx.inlinehilite
-  - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - attr_list
   - sane_lists
   - tables


### PR DESCRIPTION
- Add single account transition guide and migration paths for Lake Formation
- Added Apache Ranger migration guide for Lake Formation
- Did a tiny bit of re-organization of pages in the adopting LF section

**Single Account transition guide:**
Introduces comprehensive documentation for transitioning to Lake Formation
in a single account setup, covering two migration paths:

Per-resource approach: grants permissions on specific Glue/S3 resources
Per-user approach: maps existing IAM policies to LF permissions
Includes a full transition guide (lake-formation-transition-guide-single-account.md)
with step-by-step instructions, updated the adopting-lake-formation overview to
reference the new content, and updated mkdocs.yml navigation to surface both paths.

**Ranger migration guide**
Documents the structural differences between Ranger and Lake Formation
(policy model, enforcement, identity, catalog), and provides actionable
migration guidance for deny/except policies, tag-based access control,
security zones, LDAP/AD to IAM identity mapping, and HDFS to S3 access
patterns.
