### PR TITLE
Added a section on Auditing with LF

### DIFF
--- a/content/adopting-lake-formation/transition-guide/apache-ranger-to-lake-formation.md
+++ b/content/adopting-lake-formation/transition-guide/apache-ranger-to-lake-formation.md
@@ -41,8 +41,6 @@ Apache Ranger can enforce policies against resources in either a Hive Metastore 
 
 This creates a hard dependency in migration sequencing: **catalog migration to GDC must complete before policy translation can begin.** Ranger policies reference catalog resources by name (database, table, column). If those resources do not yet exist in GDC, there is nothing for a Lake Formation grant to bind to.
 
-For detailed steps on migrating Hive Metastore metadata into the Glue Data Catalog, refer to the [HMS to Glue Data Catalog migration guide](https://aws.highspot.com/items/6a284d07987cca17721d8f59).
-
 ### Migration action
 
 Complete the Hive Metastore to Glue Data Catalog migration before beginning policy translation. Validate that all databases, tables, and partitions referenced by existing Ranger policies are present in GDC. Any resource missing from GDC will be an orphaned policy with no equivalent grant target in Lake Formation.

--- a/content/auditing/lake-formation-cloudtrail.md
+++ b/content/auditing/lake-formation-cloudtrail.md
@@ -1,0 +1,532 @@
+# Lake Formation CloudTrail Events
+
+When an integrated analytics engine needs to read a Lake Formation–governed table or data location, it calls Lake Formation's `GetDataAccess` API. Lake Formation evaluates the request against the grants you have defined and, if the request is authorized, vends short-lived credentials scoped to the resource. Every one of these calls is recorded in AWS CloudTrail as a `GetDataAccess` event with `eventSource: lakeformation.amazonaws.com`.
+
+`GetDataAccess` is a **read-only management event** (`readOnly: true`, `managementEvent: true`). It is the authoritative record of *who was authorized to access what, through which engine* — the starting point for any Lake Formation audit trail. See the [Lake Formation CloudTrail documentation](https://docs.aws.amazon.com/lake-formation/latest/dg/logging-using-cloudtrail.html) for how to enable and locate these events.
+
+!!! note "About the examples on this page"
+
+    All events below are **sanitized samples**. Real values have been replaced with placeholders so nothing sensitive is exposed:
+
+    | Real value | Placeholder used |
+    | --- | --- |
+    | AWS account ID | `111122223333` |
+    | S3 bucket name | `amzn-s3-demo-bucket` |
+    | Access key ID (`accessKeyId`) | `AKIAIOSFODNN7EXAMPLE` |
+    | Principal IDs (`AROA…`) and session suffixes | short example values |
+    | Request / event IDs, `x-amz-id-2` | example UUIDs |
+    | Query IDs, authorization IDs, table IDs, cluster IDs | example values |
+    | Customer IP addresses | `203.0.113.10` (from the [documentation range](https://datatracker.ietf.org/doc/html/rfc5737)) |
+
+    Engine and service identifiers — `sourceIPAddress` service endpoints (for example `athena.amazonaws.com`), `platformType`, and `requesterService` — are kept as-is, because they are documented, non-sensitive, and are exactly the fields you use to identify the calling engine.
+
+## Example events per engine
+
+Each integrated engine emits the same `GetDataAccess` event shape. The differences that matter for auditing are in a handful of fields — the calling identity, the engine signature, and the requested resource — covered in the [field reference](#field-reference) below.
+
+### Amazon EMR Serverless — Full Table Access
+
+In Full Table Access (FTA) mode the request carries a `tableArn` with no cell-filtering metadata. `requesterService` is `UNKNOWN` and the engine is identified from `sourceIPAddress` / `userAgent` and the `platformType` inside `additionalAuditContext`.
+
+```json
+{
+  "eventVersion": "1.11",
+  "userIdentity": {
+    "type": "AssumedRole",
+    "principalId": "AROAEXAMPLEEMRS:00exampleJob1,00exampleAttempt1",
+    "arn": "arn:aws:sts::111122223333:assumed-role/EmrServerlessRuntimeRole/00exampleJob1,00exampleAttempt1",
+    "accountId": "111122223333",
+    "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+    "sessionContext": {
+      "sessionIssuer": {
+        "type": "Role",
+        "principalId": "AROAEXAMPLEEMRS",
+        "arn": "arn:aws:iam::111122223333:role/EmrServerlessRuntimeRole",
+        "accountId": "111122223333",
+        "userName": "EmrServerlessRuntimeRole"
+      },
+      "attributes": {
+        "creationDate": "2026-07-01T22:35:24Z",
+        "mfaAuthenticated": "false"
+      }
+    },
+    "invokedBy": "ops.emr-serverless.amazonaws.com"
+  },
+  "eventTime": "2026-07-01T22:36:08Z",
+  "eventSource": "lakeformation.amazonaws.com",
+  "eventName": "GetDataAccess",
+  "awsRegion": "us-east-2",
+  "sourceIPAddress": "ops.emr-serverless.amazonaws.com",
+  "userAgent": "ops.emr-serverless.amazonaws.com",
+  "requestParameters": {
+    "tableArn": "arn:aws:glue:us-east-2:111122223333:table/flights/flights_local",
+    "auditContext": {
+      "additionalAuditContext": "{\"platformType\":\"EMR_SERVERLESS\",\"jobIdentifier\":\"00exampleJob1/00exampleAttempt1\"}"
+    }
+  },
+  "responseElements": null,
+  "additionalEventData": {
+    "requesterService": "UNKNOWN",
+    "LakeFormationTrustedCallerInvocation": "true",
+    "lakeFormationPrincipal": "arn:aws:iam::111122223333:role/EmrServerlessRuntimeRole",
+    "lakeFormationRoleSessionName": "AWSLF-00-NA-111122223333-EXAMPLE01"
+  },
+  "requestID": "aaaaaaaa-1111-2222-3333-444444444444",
+  "eventID": "bbbbbbbb-1111-2222-3333-555555555555",
+  "readOnly": true,
+  "eventType": "AwsApiCall",
+  "managementEvent": true,
+  "recipientAccountId": "111122223333",
+  "sharedEventID": "cccccccc-1111-2222-3333-666666666666",
+  "vpcEndpointId": "emr-serverless.amazonaws.com",
+  "vpcEndpointAccountId": "emr-serverless.amazonaws.com",
+  "eventCategory": "Management"
+}
+```
+
+### Amazon EMR Serverless — Fine-Grained Access Control
+
+In Fine-Grained Access Control (FGAC) mode the request adds `permissions` (for example `SELECT`), `supportedPermissionTypes: ["CELL_FILTER_PERMISSION"]`, and a `querySessionContext`. `requesterService` is populated (`EMRSERVERLESS`).
+
+```json
+{
+  "eventVersion": "1.11",
+  "userIdentity": {
+    "type": "AssumedRole",
+    "principalId": "AROAEXAMPLEFGAC:00exampleJob2,00exampleAttempt2",
+    "arn": "arn:aws:sts::111122223333:assumed-role/EmrServerlessRuntimeRole-LF-FGAC/00exampleJob2,00exampleAttempt2",
+    "accountId": "111122223333",
+    "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+    "sessionContext": {
+      "sessionIssuer": {
+        "type": "Role",
+        "principalId": "AROAEXAMPLEFGAC",
+        "arn": "arn:aws:iam::111122223333:role/EmrServerlessRuntimeRole-LF-FGAC",
+        "accountId": "111122223333",
+        "userName": "EmrServerlessRuntimeRole-LF-FGAC"
+      },
+      "attributes": {
+        "creationDate": "2026-07-02T14:39:26Z",
+        "mfaAuthenticated": "false"
+      }
+    },
+    "invokedBy": "ops.emr-serverless.amazonaws.com"
+  },
+  "eventTime": "2026-07-02T14:41:04Z",
+  "eventSource": "lakeformation.amazonaws.com",
+  "eventName": "GetDataAccess",
+  "awsRegion": "us-east-2",
+  "sourceIPAddress": "ops.emr-serverless.amazonaws.com",
+  "userAgent": "ops.emr-serverless.amazonaws.com",
+  "requestParameters": {
+    "tableArn": "arn:aws:glue:us-east-2:111122223333:table/flights/flights_local",
+    "permissions": ["SELECT"],
+    "auditContext": {
+      "additionalAuditContext": "{\"platformType\":\"EMR_SERVERLESS\",\"jobIdentifier\":\"00exampleJob2/00exampleAttempt2\"}"
+    },
+    "supportedPermissionTypes": ["CELL_FILTER_PERMISSION"],
+    "querySessionContext": {
+      "queryId": "11111111-2222-3333-4444-555555555555",
+      "queryStartTime": "Jul 2, 2026 2:41:00 PM",
+      "queryAuthorizationId": "EXAMPLEQUERYAUTHID01"
+    }
+  },
+  "responseElements": null,
+  "additionalEventData": {
+    "requesterService": "EMRSERVERLESS",
+    "LakeFormationTrustedCallerInvocation": "true",
+    "lakeFormationPrincipal": "arn:aws:iam::111122223333:role/EmrServerlessRuntimeRole-LF-FGAC",
+    "lakeFormationRoleSessionName": "AWSLF-00-NA-111122223333-EXAMPLE02"
+  },
+  "requestID": "dddddddd-1111-2222-3333-777777777777",
+  "eventID": "eeeeeeee-1111-2222-3333-888888888888",
+  "readOnly": true,
+  "eventType": "AwsApiCall",
+  "managementEvent": true,
+  "recipientAccountId": "111122223333",
+  "sharedEventID": "ffffffff-1111-2222-3333-999999999999",
+  "vpcEndpointId": "emr-serverless.amazonaws.com",
+  "vpcEndpointAccountId": "emr-serverless.amazonaws.com",
+  "eventCategory": "Management"
+}
+```
+
+### Amazon EMR on EC2 — Full Table Access
+
+The `GetDataAccess` event for a Full Table Access read on EMR on EC2 is structurally identical to the [EMR Serverless FTA example](#amazon-emr-serverless-full-table-access) above — a `tableArn` request with no cell-filtering metadata and `requesterService: UNKNOWN`. The distinguishing fields are the runtime role ARN and `platformType: EMR_ON_EC2` inside `additionalAuditContext` (see the FGAC example below for the EMR-on-EC2 identity and engine signature).
+
+### Amazon EMR on EC2 — Fine-Grained Access Control
+
+EMR on EC2 calls Lake Formation directly, so `sourceIPAddress` is the cluster's IP and `userAgent` is an AWS SDK string (rather than a service endpoint). FGAC access tagged by EMR also carries `LakeFormationAuthorizedSessionTag: "LakeFormationAuthorizedCaller:Amazon EMR"`.
+
+```json
+{
+  "eventVersion": "1.11",
+  "userIdentity": {
+    "type": "AssumedRole",
+    "principalId": "AROAEXAMPLEEC2:5000",
+    "arn": "arn:aws:sts::111122223333:assumed-role/human-resource-runtime-role/5000",
+    "accountId": "111122223333",
+    "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+    "sessionContext": {
+      "sessionIssuer": {
+        "type": "Role",
+        "principalId": "AROAEXAMPLEEC2",
+        "arn": "arn:aws:iam::111122223333:role/human-resource-runtime-role",
+        "accountId": "111122223333",
+        "userName": "human-resource-runtime-role"
+      },
+      "attributes": {
+        "creationDate": "2026-07-08T17:01:19Z",
+        "mfaAuthenticated": "false"
+      }
+    }
+  },
+  "eventTime": "2026-07-08T17:02:35Z",
+  "eventSource": "lakeformation.amazonaws.com",
+  "eventName": "GetDataAccess",
+  "awsRegion": "us-east-2",
+  "sourceIPAddress": "203.0.113.10",
+  "userAgent": "aws-sdk-java/2.42.12 md/io#sync md/http#Apache ua/2.1 api/LakeFormation#2.42.x os/Linux lang/java#17.0.19 md/vendor#Amazon.com_Inc.",
+  "requestParameters": {
+    "tableArn": "arn:aws:glue:us-east-2:111122223333:table/flights/flights_local",
+    "permissions": ["SELECT"],
+    "auditContext": {
+      "additionalAuditContext": "{\"platformType\":\"EMR_ON_EC2\",\"jobIdentifier\":\"j-EXAMPLECLUSTER/application_1234567890123_0001\"}"
+    },
+    "supportedPermissionTypes": ["CELL_FILTER_PERMISSION"],
+    "querySessionContext": {
+      "queryId": "22222222-3333-4444-5555-666666666666",
+      "queryStartTime": "Jul 8, 2026 5:02:34 PM",
+      "queryAuthorizationId": "EXAMPLEQUERYAUTHID02"
+    }
+  },
+  "responseElements": null,
+  "additionalEventData": {
+    "requesterService": "UNKNOWN",
+    "LakeFormationAuthorizedSessionTag": "LakeFormationAuthorizedCaller:Amazon EMR",
+    "LakeFormationTrustedCallerInvocation": "true",
+    "lakeFormationPrincipal": "arn:aws:iam::111122223333:role/human-resource-runtime-role",
+    "lakeFormationRoleSessionName": "AWSLF-00-NA-111122223333-EXAMPLE03"
+  },
+  "requestID": "12341234-1111-2222-3333-123412341234",
+  "eventID": "56785678-1111-2222-3333-567856785678",
+  "readOnly": true,
+  "eventType": "AwsApiCall",
+  "managementEvent": true,
+  "recipientAccountId": "111122223333",
+  "eventCategory": "Management",
+  "tlsDetails": {
+    "tlsVersion": "TLSv1.3",
+    "cipherSuite": "TLS_AES_128_GCM_SHA256",
+    "clientProvidedHostHeader": "lakeformation.us-east-2.amazonaws.com"
+  }
+}
+```
+
+### Amazon Athena (engine v3) — Fine-Grained Access Control
+
+Athena queries FGAC-enabled tables through Lake Formation; Full Table Access is not supported. Athena events set `requesterService: ATHENA`, `cellLevelSecurityEnforced: true`, and an `expectedTableId`, and carry the Athena `queryId` in `additionalAuditContext`.
+
+Unlike the other engines, Athena writes `additionalAuditContext` as a loosely-formatted string (`{queryId: <id>}`) rather than escaped JSON, so `json_extract_scalar` does not parse it — treat it as an opaque string when querying.
+
+```json
+{
+  "eventVersion": "1.11",
+  "userIdentity": {
+    "type": "AssumedRole",
+    "principalId": "AROAEXAMPLEADMIN:admin-session",
+    "arn": "arn:aws:sts::111122223333:assumed-role/Admin/admin-session",
+    "accountId": "111122223333",
+    "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+    "sessionContext": {
+      "sessionIssuer": {
+        "type": "Role",
+        "principalId": "AROAEXAMPLEADMIN",
+        "arn": "arn:aws:iam::111122223333:role/Admin",
+        "accountId": "111122223333",
+        "userName": "Admin"
+      },
+      "attributes": {
+        "creationDate": "2026-07-01T20:43:33Z",
+        "mfaAuthenticated": "false"
+      }
+    },
+    "invokedBy": "athena.amazonaws.com"
+  },
+  "eventTime": "2026-07-01T21:01:47Z",
+  "eventSource": "lakeformation.amazonaws.com",
+  "eventName": "GetDataAccess",
+  "awsRegion": "us-east-2",
+  "sourceIPAddress": "athena.amazonaws.com",
+  "userAgent": "athena.amazonaws.com",
+  "requestParameters": {
+    "tableArn": "arn:aws:glue:us-east-2:111122223333:table/flights/flights_local",
+    "permissions": ["SELECT"],
+    "auditContext": {
+      "additionalAuditContext": "{queryId: 33333333-4444-5555-6666-777777777777}"
+    },
+    "cellLevelSecurityEnforced": true,
+    "expectedTableId": "EXAMPLETABLEID0000000000000000"
+  },
+  "responseElements": null,
+  "additionalEventData": {
+    "requesterService": "ATHENA",
+    "LakeFormationTrustedCallerInvocation": "true",
+    "lakeFormationPrincipal": "arn:aws:iam::111122223333:role/Admin",
+    "lakeFormationRoleSessionName": "AWSLF-00-AT-111122223333-EXAMPLE04"
+  },
+  "requestID": "43214321-1111-2222-3333-432143214321",
+  "eventID": "87658765-1111-2222-3333-876587658765",
+  "readOnly": true,
+  "eventType": "AwsApiCall",
+  "managementEvent": true,
+  "recipientAccountId": "111122223333",
+  "eventCategory": "Management"
+}
+```
+
+### AWS Glue ETL — Fine-Grained Access Control
+
+Glue ETL jobs (Glue 5.1+) access FGAC tables through Lake Formation with `platformType: GLUE_ETL`. As with EMR Serverless, `requesterService` is `UNKNOWN` and the engine is identified from `sourceIPAddress` / `userAgent` (`glue.amazonaws.com`) and `platformType`.
+
+```json
+{
+  "eventVersion": "1.11",
+  "userIdentity": {
+    "type": "AssumedRole",
+    "principalId": "AROAEXAMPLEGLUE:GlueJobRunnerSession",
+    "arn": "arn:aws:sts::111122223333:assumed-role/GlueServiceRole-NoS3/GlueJobRunnerSession",
+    "accountId": "111122223333",
+    "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+    "sessionContext": {
+      "sessionIssuer": {
+        "type": "Role",
+        "principalId": "AROAEXAMPLEGLUE",
+        "arn": "arn:aws:iam::111122223333:role/GlueServiceRole-NoS3",
+        "accountId": "111122223333",
+        "userName": "GlueServiceRole-NoS3"
+      },
+      "attributes": {
+        "creationDate": "2026-07-09T17:20:10Z",
+        "mfaAuthenticated": "false"
+      }
+    },
+    "invokedBy": "glue.amazonaws.com"
+  },
+  "eventTime": "2026-07-09T17:24:08Z",
+  "eventSource": "lakeformation.amazonaws.com",
+  "eventName": "GetDataAccess",
+  "awsRegion": "us-east-2",
+  "sourceIPAddress": "glue.amazonaws.com",
+  "userAgent": "glue.amazonaws.com",
+  "requestParameters": {
+    "tableArn": "arn:aws:glue:us-east-2:111122223333:table/flights/flights_local",
+    "permissions": ["SELECT"],
+    "auditContext": {
+      "additionalAuditContext": "{\"platformType\":\"GLUE_ETL\",\"jobIdentifier\":\"EXAMPLE-glue-job-run-id/\"}"
+    },
+    "supportedPermissionTypes": ["CELL_FILTER_PERMISSION"],
+    "querySessionContext": {
+      "queryId": "44444444-5555-6666-7777-888888888888",
+      "queryStartTime": "Jul 9, 2026 5:24:05 PM",
+      "queryAuthorizationId": "EXAMPLEQUERYAUTHID03"
+    }
+  },
+  "responseElements": null,
+  "additionalEventData": {
+    "requesterService": "UNKNOWN",
+    "LakeFormationTrustedCallerInvocation": "true",
+    "lakeFormationPrincipal": "arn:aws:iam::111122223333:role/GlueServiceRole-NoS3",
+    "lakeFormationRoleSessionName": "AWSLF-00-NA-111122223333-EXAMPLE05"
+  },
+  "requestID": "9a9a9a9a-1111-2222-3333-9a9a9a9a9a9a",
+  "eventID": "9b9b9b9b-1111-2222-3333-9b9b9b9b9b9b",
+  "readOnly": true,
+  "eventType": "AwsApiCall",
+  "managementEvent": true,
+  "recipientAccountId": "111122223333",
+  "eventCategory": "Management"
+}
+```
+
+### Amazon Redshift (provisioned)
+
+Redshift Spectrum requests carry `durationSeconds`, `cellLevelSecurityEnforced`, and `expectedTableId` (no `platformType`). `requesterService` is `REDSHIFT`, and console-driven sessions include `sessionCredentialFromConsole: "true"`.
+
+```json
+{
+  "eventVersion": "1.11",
+  "userIdentity": {
+    "type": "AssumedRole",
+    "principalId": "AROAEXAMPLEADMIN:admin-session",
+    "arn": "arn:aws:sts::111122223333:assumed-role/Admin/admin-session",
+    "accountId": "111122223333",
+    "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+    "sessionContext": {
+      "sessionIssuer": {
+        "type": "Role",
+        "principalId": "AROAEXAMPLEADMIN",
+        "arn": "arn:aws:iam::111122223333:role/Admin",
+        "accountId": "111122223333",
+        "userName": "Admin"
+      },
+      "attributes": {
+        "creationDate": "2026-07-08T15:12:27Z",
+        "mfaAuthenticated": "false"
+      }
+    },
+    "invokedBy": "redshift.amazonaws.com"
+  },
+  "eventTime": "2026-07-08T22:01:13Z",
+  "eventSource": "lakeformation.amazonaws.com",
+  "eventName": "GetDataAccess",
+  "awsRegion": "us-east-2",
+  "sourceIPAddress": "redshift.amazonaws.com",
+  "userAgent": "redshift.amazonaws.com",
+  "requestParameters": {
+    "tableArn": "arn:aws:glue:us-east-2:111122223333:table/flights/flights_local",
+    "durationSeconds": 3600,
+    "cellLevelSecurityEnforced": true,
+    "expectedTableId": "EXAMPLETABLEID0000000000000000"
+  },
+  "responseElements": null,
+  "additionalEventData": {
+    "requesterService": "REDSHIFT",
+    "LakeFormationTrustedCallerInvocation": "true",
+    "lakeFormationPrincipal": "arn:aws:iam::111122223333:role/Admin",
+    "lakeFormationRoleSessionName": "AWSLF-00-RE-111122223333-EXAMPLE06"
+  },
+  "requestID": "5c5c5c5c-1111-2222-3333-5c5c5c5c5c5c",
+  "eventID": "5d5d5d5d-1111-2222-3333-5d5d5d5d5d5d",
+  "readOnly": true,
+  "eventType": "AwsApiCall",
+  "managementEvent": true,
+  "recipientAccountId": "111122223333",
+  "eventCategory": "Management",
+  "sessionCredentialFromConsole": "true"
+}
+```
+
+### Amazon Redshift Serverless
+
+Redshift Serverless is identified by `sourceIPAddress` / `userAgent` of `redshift-serverless.amazonaws.com`. Its `additionalAuditContext` embeds the invoking Redshift database user rather than a `platformType`.
+
+```json
+{
+  "eventVersion": "1.11",
+  "userIdentity": {
+    "type": "AssumedRole",
+    "principalId": "AROAEXAMPLEADMIN:admin-session",
+    "arn": "arn:aws:sts::111122223333:assumed-role/Admin/admin-session",
+    "accountId": "111122223333",
+    "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+    "sessionContext": {
+      "sessionIssuer": {
+        "type": "Role",
+        "principalId": "AROAEXAMPLEADMIN",
+        "arn": "arn:aws:iam::111122223333:role/Admin",
+        "accountId": "111122223333",
+        "userName": "Admin"
+      },
+      "attributes": {
+        "creationDate": "2026-07-08T15:12:27Z",
+        "mfaAuthenticated": "false"
+      }
+    },
+    "invokedBy": "redshift-serverless.amazonaws.com"
+  },
+  "eventTime": "2026-07-08T21:19:12Z",
+  "eventSource": "lakeformation.amazonaws.com",
+  "eventName": "GetDataAccess",
+  "awsRegion": "us-east-2",
+  "sourceIPAddress": "redshift-serverless.amazonaws.com",
+  "userAgent": "redshift-serverless.amazonaws.com",
+  "requestParameters": {
+    "tableArn": "arn:aws:glue:us-east-2:111122223333:table/flights/flights_local",
+    "durationSeconds": 3600,
+    "auditContext": {
+      "additionalAuditContext": "{\"invokedBy\":\"arn:aws:redshift:us-east-2:111122223333:dbuser:serverless-111122223333-EXAMPLE/IAMR:Admin\",\"transactionId\":\"3309\",\"queryId\":\"NULL\",\"isConcurrencyScalingQuery\":\"false\"}"
+    },
+    "cellLevelSecurityEnforced": true,
+    "expectedTableId": "EXAMPLETABLEID0000000000000000"
+  },
+  "responseElements": null,
+  "additionalEventData": {
+    "requesterService": "UNKNOWN",
+    "LakeFormationTrustedCallerInvocation": "true",
+    "lakeFormationPrincipal": "arn:aws:iam::111122223333:role/Admin",
+    "lakeFormationRoleSessionName": "AWSLF-00-RE-111122223333-EXAMPLE07"
+  },
+  "requestID": "5e5e5e5e-1111-2222-3333-5e5e5e5e5e5e",
+  "eventID": "5f5f5f5f-1111-2222-3333-5f5f5f5f5f5f",
+  "readOnly": true,
+  "eventType": "AwsApiCall",
+  "managementEvent": true,
+  "recipientAccountId": "111122223333",
+  "eventCategory": "Management",
+  "sessionCredentialFromConsole": "true"
+}
+```
+
+## Field reference
+
+The fields most useful for auditing fall into three groups: **who** made the request (identity), **what engine** made it (source/engine), and **what** they were authorized to access (resource).
+
+### Identity fields
+
+| Field | What it tells you |
+| --- | --- |
+| `userIdentity.arn` | The assumed-role session ARN that called `GetDataAccess` (includes the session name suffix). |
+| `userIdentity.sessionContext.sessionIssuer.arn` | The underlying IAM role — the stable identity to group activity by, regardless of session. |
+| `additionalEventData.lakeFormationPrincipal` | The IAM principal Lake Formation evaluated grants against. This is the principal whose permissions authorized the access. |
+| `additionalEventData.lakeFormationRoleSessionName` | The session name (for example `AWSLF-00-AT-111122223333-EXAMPLE04`) of the short-lived credential Lake Formation vends. **This is the key that links a `GetDataAccess` event to the S3 object accesses that follow it** — see [Querying Audit Data](querying-audit-data.md). |
+
+### Source / engine fields
+
+| Field | What it tells you |
+| --- | --- |
+| `sourceIPAddress` / `userAgent` | For managed engines these are a service endpoint (for example `athena.amazonaws.com`); for EMR on EC2 the source is the cluster IP and the agent is an AWS SDK string. |
+| `additionalEventData.requesterService` | The calling service when populated (`ATHENA`, `REDSHIFT`, `EMRSERVERLESS`). Often `UNKNOWN` for EMR Serverless FTA, EMR on EC2, Glue ETL, and Redshift Serverless — fall back to the fields below. |
+| `requestParameters.auditContext.additionalAuditContext.platformType` | The engine type where present (`EMR_SERVERLESS`, `EMR_ON_EC2`, `GLUE_ETL`). |
+| `additionalAuditContext.jobIdentifier` | The job/application identifier of the caller — ties the access to a specific EMR or Glue job run. |
+| `requestParameters.querySessionContext.queryId` / `queryAuthorizationId` | The engine's query identifiers, for correlating back to a specific query. |
+
+### Resource fields
+
+| Field | What it tells you |
+| --- | --- |
+| `requestParameters.tableArn` | The Glue Data Catalog table being accessed (table-level request). |
+| `requestParameters.dataLocations` | Present instead of `tableArn` when access is requested by S3 data location rather than by table. |
+| `requestParameters.permissions` | The permissions being exercised, for example `SELECT`. |
+| `requestParameters.supportedPermissionTypes` | Includes `CELL_FILTER_PERMISSION` when the request is subject to fine-grained (row/column/cell) filtering. |
+| `requestParameters.cellLevelSecurityEnforced` | `true` when cell-level security was enforced for the access (seen from Athena and Redshift). |
+
+#### Telling FTA, FGAC, and direct-S3 access apart
+
+The resource fields also reveal which access mode was used:
+
+- **Fine-Grained Access Control (FGAC):** the event carries `permissions` (for example `["SELECT"]`) together with `cellLevelSecurityEnforced: true` and/or `supportedPermissionTypes: ["CELL_FILTER_PERMISSION"]`, usually alongside a populated `requesterService` and `querySessionContext`.
+- **Full Table Access (FTA):** the event has a `tableArn` (with `auditContext`) but **no** `permissions` and **no** cell-filtering metadata; `requesterService` is typically `UNKNOWN`.
+- **Access by data location (direct S3):** `requestParameters.dataLocations` is present instead of `tableArn`. Note that these requests do **not** populate `lakeFormationRoleSessionName`, which limits how they can be correlated to S3 events (see the limitations in [Querying Audit Data](querying-audit-data.md)).
+- EMR-tagged FGAC access additionally carries `additionalEventData.LakeFormationAuthorizedSessionTag: "LakeFormationAuthorizedCaller:Amazon EMR"`.
+
+## Quick reference: identifying the engine
+
+Use this table to identify which engine produced a `GetDataAccess` event from its signature fields.
+
+| Engine | `sourceIPAddress` / `userAgent` | `platformType` | Other signals |
+| --- | --- | --- | --- |
+| EMR Serverless | `ops.emr-serverless.amazonaws.com` | `EMR_SERVERLESS` | `requesterService` `UNKNOWN` (FTA) or `EMRSERVERLESS` (FGAC) |
+| EMR on EC2 | Cluster IP / `aws-sdk-java/…` | `EMR_ON_EC2` | `LakeFormationAuthorizedSessionTag: LakeFormationAuthorizedCaller:Amazon EMR` |
+| Athena (v3) | `athena.amazonaws.com` | *(none)* | `requesterService` `ATHENA`; `queryId` in `additionalAuditContext`; FGAC only |
+| Glue ETL | `glue.amazonaws.com` | `GLUE_ETL` | `requesterService` `UNKNOWN` |
+| Redshift (provisioned) | `redshift.amazonaws.com` | *(none)* | `requesterService` `REDSHIFT`; `durationSeconds` present |
+| Redshift Serverless | `redshift-serverless.amazonaws.com` | *(none)* | `additionalAuditContext.invokedBy` names the Redshift `dbuser` |
+
+## Caveats
+
+!!! warning "Access-mode limitations on EMR and Glue"
+
+    - Table access directly by S3 data location through Lake Formation is **not supported** when FGAC is enabled on EMR or Glue.
+    - EMR and Glue do **not** support Full Table Access mode with Lake Formation for Apache Iceberg tables.

--- a/content/auditing/overview.md
+++ b/content/auditing/overview.md
@@ -1,0 +1,37 @@
+# Auditing in Lake Formation
+
+This section covers how to audit data access in a Lake Formation-governed data lake — capturing who accessed what, when, through which engine, and whether the access was authorized — so you can meet compliance requirements and investigate incidents with confidence. We have provided sample Amazon Athena queries in [Querying Audit Data](querying-audit-data.md), which correlates Lake Formation authorization events with the underlying S3 object access to produce an end-to-end engine-to-S3 mapping — for each S3 object read or written, it shows which principal was authorized, by which engine, against which catalog resource.
+
+## Why auditing matters
+
+Auditing is how you verify that your access controls are working as intended. Specifically, it lets you:
+
+- **Validate least-privilege grants.** Confirm that principals are exercising only the permissions they have been granted, and that unused grants can be safely removed.
+- **Detect policy drift and anomalous access.** Identify unexpected principals, engines, or access patterns before they become security incidents.
+- **Produce compliance evidence.** Demonstrate to auditors that access to sensitive data is controlled and recorded.
+- **Support incident forensics.** Reconstruct the exact sequence of access events when an incident needs investigation.
+
+## What Lake Formation auditing adds over IAM alone
+
+When a query engine such as Athena, Redshift Spectrum, or EMR requests access to a Lake Formation-governed resource, Lake Formation evaluates the request and emits a `GetDataAccess` CloudTrail event. This event captures the *authorization decision* together with rich context that raw S3 data events alone cannot provide:
+
+- **Which principal** made the request (IAM role or user ARN)
+- **Which resource** was authorized (database, table, or column set)
+- **Which engine** submitted the request and, where available, the associated query ID
+- **Whether Fine-Grained Access Control (FGAC) or Full Table Access (FTA) applied** — distinguishing between column- or row-level filtering and pass-through access
+
+This context is essential for understanding *why* a set of S3 objects was read, not just that it was.
+
+## The end-to-end picture
+
+A governed data access flows through three stages:
+
+1. A query engine calls Lake Formation's `GetDataAccess` API. Lake Formation evaluates the grants, records the authorization decision in CloudTrail, and — if approved — vends a short-lived, scoped session credential.
+2. The engine uses that credential to read or write the underlying S3 objects. S3 records this access in its own audit trail (CloudTrail S3 Data Events or S3 Server Access Logs).
+3. Full auditing requires **correlating** the Lake Formation authorization events with the S3 access records. Lake Formation stamps the credential it vends with a distinctive session name (beginning `AWSLF-`); that same session name appears in the `GetDataAccess` event (as `lakeFormationRoleSessionName`) and in the identity of the S3 requests made with the credential, which is what makes the join possible.
+
+## In this section
+
+- [Lake Formation CloudTrail Events](lake-formation-cloudtrail.md) — the `GetDataAccess` event structure, example events per query engine, and a field reference.
+- [S3 Audit Events](s3-audit-events.md) — CloudTrail S3 Data Events vs. S3 Server Access Logs, and how to choose between them.
+- [Querying Audit Data](querying-audit-data.md) — Athena queries that join S3 access records to Lake Formation authorization events.

--- a/content/auditing/querying-audit-data.md
+++ b/content/auditing/querying-audit-data.md
@@ -1,0 +1,276 @@
+# Querying Audit Data
+
+The value of auditing comes from **correlating** the Lake Formation authorization events ([`GetDataAccess`](lake-formation-cloudtrail.md)) with the S3 records of the objects that were actually read or written ([CloudTrail S3 Data Events or S3 Server Access Logs](s3-audit-events.md)). Most teams do this with Amazon Athena — either on demand, or on a schedule that materializes a curated audit table for dashboards and alerting.
+
+The two queries below stitch the two sides together. Use the first if you capture S3 access with **CloudTrail S3 Data Events**, and the second if you use **S3 Server Access Logs**.
+
+!!! note "Substitute your own table names"
+
+    The queries reference example Athena table names built from the account ID `111122223333` (for example `cloudtrail_logs_aws_cloudtrail_logs_111122223333_us_east_2` and `s3_access_logs_2026_07`). Replace them with the names of the Glue Data Catalog tables over your own CloudTrail, S3 Data Event, and S3 Server Access Log locations.
+
+## Query 1 — CloudTrail S3 Data Events joined to Lake Formation
+
+```sql
+-- s3_access: one row per S3 object operation, from the CloudTrail S3 data events.
+with s3_access as (
+    select
+        eventtime as s3_eventtime,
+        -- Reconstruct the full s3:// path from the request parameters.
+        concat('s3://', json_extract_scalar(requestparameters, '$.bucketName'), '/',
+            json_extract_scalar(requestparameters, '$.key')) as s3_object_path,
+        -- Access made under a Lake Formation-vended credential carries a session name
+        -- beginning 'AWSLF-'. Anything else is direct (non-LF) S3 access.
+        case
+            when starts_with(reverse(split(reverse(useridentity.arn), '/')[1]), 'AWSLF-') then 'LF'
+            else 'DIRECT'
+        end as access_method,
+        eventid as s3_eventid,
+        -- Resolve the underlying IAM identity (the role, not the transient session).
+        case
+            when useridentity.type = 'IAMUser' then useridentity.arn
+            when useridentity.type = 'AssumedRole' then useridentity.sessioncontext.sessionissuer.arn
+            else null
+        end as s3_iam_arn,
+        useridentity.arn as s3_sts_arn,
+        -- Extract the session name (last '/'-delimited segment of the ARN). This is the
+        -- key we join on: it matches lakeFormationRoleSessionName on the LF event.
+        reverse(split(reverse(useridentity.arn), '/')[1]) as s3_sts_session_name,
+        sourceipaddress as s3_sourceipaddress,
+        useragent as s3_sourceuseragent,
+        errorcode as s3_errorcode
+    from
+        cloudtrail_logs_aws_cloudtrail_logs_111122223333_us_east_2
+    -- Filter to the S3 events we care about. Add or remove events based on your use case.
+    where
+        eventname in ('GetObject', 'PutObject', 'DeleteObject')
+-- lf_getdata_access: one row per Lake Formation authorization decision.
+), lf_getdata_access as (
+    select
+        -- Resolve the underlying IAM identity (the role, not the transient session).
+        case
+            when useridentity.type = 'IAMUser' then useridentity.arn
+            when useridentity.type = 'AssumedRole' then useridentity.sessioncontext.sessionissuer.arn
+            else null
+        end as lf_arn,
+        useridentity.arn as lf_sts_arn,
+        -- Identify the calling engine: managed engines are recognized by sourceIPAddress;
+        -- otherwise fall back to the platformType embedded in additionalAuditContext.
+        case
+            when sourceipaddress = 'ops.emr-serverless.amazonaws.com' then 'EMR-SERVERLESS'
+            when sourceipaddress = 'athena.amazonaws.com' then 'ATHENA'
+            when sourceipaddress = 'redshift-serverless.amazonaws.com' then 'REDSHIFT-SERVERLESS'
+            when sourceipaddress = 'redshift.amazonaws.com' then 'REDSHIFT'
+            when sourceipaddress = 'glue.amazonaws.com' then 'GLUE'
+            when json_extract_scalar(requestparameters, '$.auditContext.additionalAuditContext') is not null then
+                case when json_extract_scalar(json_extract_scalar(requestparameters,
+                    '$.auditContext.additionalAuditContext'), '$.platformType') is not null
+                    then json_extract_scalar(json_extract_scalar(requestparameters,
+                        '$.auditContext.additionalAuditContext'), '$.platformType')
+                    else 'UNKNOWN'
+                end
+            else useragent
+        end as lf_source,
+        -- Whether access was requested by table (tableArn) or by S3 data location.
+        case
+            when json_extract(requestparameters, '$.dataLocations') is not null then 'DATA_LOCATION'
+            when json_extract_scalar(requestparameters, '$.tableArn') is not null then 'TABLE'
+            else 'UNKNOWN'
+        end as lf_resource_type,
+        -- The resource that was authorized (the data location(s) or the table ARN).
+        case
+            when json_extract(requestparameters, '$.dataLocations') is not null
+                then json_format(json_extract(requestparameters, '$.dataLocations'))
+            when json_extract_scalar(requestparameters, '$.tableArn') is not null
+                then json_extract_scalar(requestparameters, '$.tableArn')
+            else 'UNKNOWN'
+        end as lf_resource,
+        -- The join key: the session name Lake Formation stamped on the vended credential.
+        case
+            when json_extract_scalar(additionaleventdata, '$.lakeFormationRoleSessionName') is not null
+                then json_extract_scalar(additionaleventdata, '$.lakeFormationRoleSessionName')
+            else 'UNKNOWN'
+        end as lf_session_name
+    from
+        cloudtrail_logs_aws_cloudtrail_logs_111122223333_us_east_2
+    where
+        eventname = 'GetDataAccess'
+)
+-- Join each S3 operation back to the LF authorization that vended its credential.
+select
+    s3.s3_eventtime,
+    s3.s3_object_path,
+    access_method,
+    lf_resource,
+    -- For LF-mediated access, report the engine; for direct access, just 'DIRECT'.
+    case when access_method = 'LF' then lf_source else access_method end as req_source,
+    -- Prefer the LF principal when the row joined; otherwise the S3 caller.
+    case when lf_sts_arn is not null then lf_sts_arn else s3_sts_arn end as end_user_arn,
+    lf.*
+from
+    s3_access s3
+-- LEFT OUTER JOIN so S3 access with no matching LF event (e.g. direct access) is still shown.
+left outer join
+    lf_getdata_access lf
+on
+    s3.s3_sts_session_name = lf.lf_session_name;
+```
+
+## Query 2 — S3 Server Access Logs joined to Lake Formation
+
+```sql
+-- s3_access: one row per S3 object operation, parsed from the S3 server access log rows.
+with s3_access as (
+    select
+        -- Server access log timestamps are strings; parse to a real timestamp (null on bad rows).
+        try(parse_datetime(requestdatetime, 'dd/MMM/yyyy:HH:mm:ss Z')) as s3_eventtime,
+        concat('s3://', bucket_name, '/', key) as s3_object_path,
+        -- Access made under a Lake Formation-vended credential carries a session name
+        -- beginning 'AWSLF-'. Anything else is direct (non-LF) S3 access.
+        case
+            when starts_with(reverse(split(reverse(requester), '/')[1]), 'AWSLF-') then 'LF'
+            else 'DIRECT'
+        end as access_method,
+        requestid as s3_eventid,
+        requester as s3_sts_arn,
+        -- Extract the session name (last '/'-delimited segment of the requester ARN). This is
+        -- the key we join on: it matches lakeFormationRoleSessionName on the LF event.
+        reverse(split(reverse(requester), '/')[1]) as s3_sts_session_name,
+        remoteip as s3_sourceipaddress,
+        useragent as s3_sourceuseragent,
+        errorcode as s3_errorcode,
+        httpstatus as s3_httpstatus,
+        -- Bucket the HTTP status into a human-readable outcome.
+        case
+            when httpstatus like '2%' then 'successful'
+            when httpstatus = '401' then 'unauthorized'
+            when httpstatus like '4%' then 'unsuccessful'
+            when httpstatus like '5%' then 'system error'
+            else 'unknown'
+        end as s3_status
+    from
+        s3_access_logs_2026_07
+    -- Filter to the S3 operations we care about. Add or remove operations based on your use case.
+    where
+        operation in ('REST.GET.OBJECT', 'REST.PUT.OBJECT', 'REST.DELETE.OBJECT')
+        -- Skip rows with no/placeholder request time (e.g. some non-request log lines).
+        and requestdatetime is not null
+        and requestdatetime <> '-'
+-- lf_getdata_access: one row per Lake Formation authorization decision.
+), lf_getdata_access as (
+    select
+        -- Resolve the underlying IAM identity (the role, not the transient session).
+        case
+            when useridentity.type = 'IAMUser' then useridentity.arn
+            when useridentity.type = 'AssumedRole' then useridentity.sessioncontext.sessionissuer.arn
+            else null
+        end as lf_arn,
+        useridentity.arn as lf_sts_arn,
+        -- Identify the calling engine: managed engines are recognized by sourceIPAddress;
+        -- otherwise fall back to the platformType embedded in additionalAuditContext.
+        case
+            when sourceipaddress = 'ops.emr-serverless.amazonaws.com' then 'EMR-SERVERLESS'
+            when sourceipaddress = 'athena.amazonaws.com' then 'ATHENA'
+            when sourceipaddress = 'redshift-serverless.amazonaws.com' then 'REDSHIFT-SERVERLESS'
+            when sourceipaddress = 'redshift.amazonaws.com' then 'REDSHIFT'
+            when sourceipaddress = 'glue.amazonaws.com' then 'GLUE'
+            when json_extract_scalar(requestparameters, '$.auditContext.additionalAuditContext') is not null then
+                case when json_extract_scalar(json_extract_scalar(requestparameters,
+                    '$.auditContext.additionalAuditContext'), '$.platformType') is not null
+                    then json_extract_scalar(json_extract_scalar(requestparameters,
+                        '$.auditContext.additionalAuditContext'), '$.platformType')
+                    else 'UNKNOWN'
+                end
+            else useragent
+        end as lf_source,
+        -- Whether access was requested by table (tableArn) or by S3 data location.
+        case
+            when json_extract(requestparameters, '$.dataLocations') is not null then 'DATA_LOCATION'
+            when json_extract_scalar(requestparameters, '$.tableArn') is not null then 'TABLE'
+            else 'UNKNOWN'
+        end as lf_resource_type,
+        -- The resource that was authorized (the data location(s) or the table ARN).
+        case
+            when json_extract(requestparameters, '$.dataLocations') is not null
+                then json_format(json_extract(requestparameters, '$.dataLocations'))
+            when json_extract_scalar(requestparameters, '$.tableArn') is not null
+                then json_extract_scalar(requestparameters, '$.tableArn')
+            else 'UNKNOWN'
+        end as lf_resource,
+        -- The join key: the session name Lake Formation stamped on the vended credential.
+        case
+            when json_extract_scalar(additionaleventdata, '$.lakeFormationRoleSessionName') is not null
+                then json_extract_scalar(additionaleventdata, '$.lakeFormationRoleSessionName')
+            else 'UNKNOWN'
+        end as lf_session_name
+    from
+        cloudtrail_logs_aws_cloudtrail_logs_111122223333_us_east_2
+    where
+        eventname = 'GetDataAccess'
+)
+-- Join each S3 operation back to the LF authorization that vended its credential.
+select
+    s3.s3_eventtime,
+    s3.s3_object_path,
+    access_method,
+    lf_resource,
+    -- For LF-mediated access, report the engine; for direct access, just 'DIRECT'.
+    case when access_method = 'LF' then lf_source else access_method end as req_source,
+    -- Prefer the LF principal when the row joined; otherwise the S3 caller.
+    case when lf_sts_arn is not null then lf_sts_arn else s3_sts_arn end as end_user_arn,
+    s3.s3_httpstatus,
+    s3.s3_status,
+    lf.*
+from
+    s3_access s3
+-- LEFT OUTER JOIN so S3 access with no matching LF event (e.g. direct access) is still shown.
+left outer join
+    lf_getdata_access lf
+on
+    s3.s3_sts_session_name = lf.lf_session_name;
+```
+
+## How the join works
+
+Both queries build two subqueries and join them on a **session name**:
+
+- **`s3_access`** parses each S3 event. The requester/identity ARN ends in a session-name suffix; the query extracts it with `reverse(split(reverse(arn), '/')[1])` as `s3_sts_session_name`. If that session name starts with `AWSLF-`, the access was performed under credentials Lake Formation vended, so `access_method` is set to `LF`; otherwise it is `DIRECT`.
+- **`lf_getdata_access`** parses each `GetDataAccess` event, deriving the calling engine (`lf_source`) from `sourceIPAddress` and the `platformType` in `additionalAuditContext`, the resource (`lf_resource`) from `tableArn` or `dataLocations`, and the session name (`lf_session_name`) from `additionalEventData.lakeFormationRoleSessionName`.
+- The two are joined on `s3_sts_session_name = lf_session_name`. Because Lake Formation stamps the vended session with the same `AWSLF-…` name that appears in the subsequent S3 request, this join reconstructs, for each S3 object access, *which principal was authorized, by which engine, against which catalog resource*.
+
+```mermaid
+flowchart LR
+    A["Engine calls GetDataAccess<br/>(lakeformation.amazonaws.com)"] -->|"authorized"| B["LF vends short-lived session<br/>session name: AWSLF-…"]
+    B --> C["S3 GetObject / PutObject<br/>requester ARN carries AWSLF-… session name"]
+    A -.->|"lakeFormationRoleSessionName"| J{{"JOIN on session name"}}
+    C -.->|"s3_sts_session_name"| J
+    D["Direct S3 access<br/>(no LF-vended session)"] --> E["S3 GetObject / PutObject<br/>session name does NOT start with AWSLF-"]
+    E -.->|"access_method = DIRECT<br/>no LF row to join"| X["Unmapped to any GetDataAccess"]
+```
+
+!!! warning "Limitations of the session-name join"
+
+    - **Direct S3 access via Lake Formation is not mappable.** When Lake Formation grants access by S3 data location (rather than by table), the `GetDataAccess` event does not populate `lakeFormationRoleSessionName`. There is no session name to link `GetDataAccess` → the assumed session → the S3 operation, so those S3 rows cannot be joined back to a Lake Formation event. They appear with `access_method = 'LF'` on the S3 side but find no matching `GetDataAccess` row (the `LEFT OUTER JOIN` leaves the `lf.*` columns null).
+    - **Access mode affects what you see.** Full Table Access and Fine-Grained Access Control produce different fields on the `GetDataAccess` event (see [Lake Formation CloudTrail Events](lake-formation-cloudtrail.md)); FGAC access by Athena/EMR/Glue reads through Lake Formation, while some engines can also read S3 directly. Interpret `access_method` and `req_source` together when reasoning about a given access.
+
+## Sample output
+
+Below is a trimmed, sanitized sample of what Query 1 returns (a subset of the columns; identifiers have been replaced with placeholders). Each row is one S3 object access, annotated with the Lake Formation authorization it correlates to. The three rows illustrate the cases described above:
+
+| s3_eventtime | s3_object_path | access_method | req_source | end_user_arn | lf_resource | lf_session_name |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2026-07-08T21:01:59Z | `s3://amzn-s3-demo-bucket/iceberg_warehouse/flights/flights_iceberg/data/year=2009/…parquet` | LF | ATHENA | `arn:aws:sts::111122223333:assumed-role/Admin/admin-session` | `arn:aws:glue:us-east-2:111122223333:table/flights/flights_iceberg` | `AWSLF-00-AT-111122223333-EXAMPLE04` |
+| 2026-07-02T15:18:45Z | `s3://amzn-s3-demo-bucket/dbs/flights/flights_local/year=2007/…` | LF | EMR-SERVERLESS | `arn:aws:sts::111122223333:assumed-role/EmrServerlessRuntimeRole-LF-FGAC/00exampleJob2,00exampleAttempt2` | `arn:aws:glue:us-east-2:111122223333:table/flights/flights_local` | `AWSLF-00-NA-111122223333-EXAMPLE02` |
+| 2026-07-06T20:45:32Z | `s3://amzn-s3-demo-bucket/dbs/flights/flights_local/year=2005/…` | LF | | `arn:aws:sts::111122223333:assumed-role/LakeFormationServiceRoleForS3Access/AWSLF-00-NA-111122223333-EXAMPLE08` | | |
+| 2026-07-01T21:06:46Z | `s3://aws-cloudtrail-logs-111122223333-us-east-2/AWSLogs/…/CloudTrail/…json.gz` | DIRECT | DIRECT | `arn:aws:sts::111122223333:assumed-role/Admin/admin-session` | | |
+
+Reading the rows:
+
+- **Rows 1–2 (fully correlated):** the S3 access joined to a `GetDataAccess` event, so `req_source` names the engine (Athena, EMR Serverless), `end_user_arn` is the Lake Formation principal, and `lf_resource` names the catalog table. This is the end-to-end engine-to-S3 mapping.
+- **Row 3 (LF, but unmapped):** the object was read under a Lake Formation–vended session (the requester ARN carries an `AWSLF-` session name, so `access_method` is `LF`), but the `lf_*` columns are empty. This is the data-location limitation described above — the `GetDataAccess` event for data-location access did not populate a session name to join on. `end_user_arn` falls back to the S3 caller (the Lake Formation S3 access role).
+- **Row 4 (direct access):** access that did **not** go through a Lake Formation session — here, a role reading CloudTrail log objects directly. `access_method` and `req_source` are both `DIRECT`, and there is no Lake Formation row to join.
+
+## Operationalizing the query
+
+- **Run on a schedule for continuous auditing.** Rather than re-scanning raw logs on demand, run the join on a daily or hourly cadence (for example with an Athena `CREATE TABLE AS SELECT` or scheduled query, or a Glue job) to materialize a curated audit table that dashboards and alerts read from.
+- **Partition the source tables by date.** CloudTrail and S3 Server Access Log tables grow quickly. Define them as partitioned tables (by year/month/day, or use partition projection) and constrain each run to the partitions for the period being audited. This bounds the amount of data scanned and keeps both cost and runtime predictable.
+- **Filter early.** The subqueries already restrict to the relevant `eventname` / `operation` values; adding a partition/time predicate in each `where` clause further reduces scan volume for scheduled runs.

--- a/content/auditing/s3-audit-events.md
+++ b/content/auditing/s3-audit-events.md
@@ -1,0 +1,46 @@
+# S3 Audit Events
+
+[Lake Formation CloudTrail Events](lake-formation-cloudtrail.md) record the *authorization* side of the story — for example, a `GetDataAccess` event captures the fact that Lake Formation vended temporary credentials to a principal for a given data location. However, these events do not show which S3 objects were subsequently read or written using those credentials. To close that gap you need S3-level auditing. AWS provides two mechanisms: **CloudTrail S3 Data Events** and **S3 Server Access Logs**. This page helps you choose between them.
+
+## Comparison
+
+| Attribute | CloudTrail S3 Data Events | S3 Server Access Logs |
+|---|---|---|
+| **Cost model** | Billed per event delivered; scoping with advanced event selectors reduces volume and cost | Free to enable; you pay S3 storage for the log files, which can be high-volume |
+| **Delivery latency** | Typically within minutes | Best-effort; can take hours |
+| **Level of detail** | Rich structured JSON — full IAM identity including the assumed-role session ARN, request parameters, and response elements | Space-delimited fields including requester, operation, object key, HTTP status code, and bytes transferred |
+| **Completeness** | Delivered on a best-effort basis but generally complete for enabled event selectors | Best-effort with no delivery guarantee; logs are delivered periodically |
+| **Join to Lake Formation via session name** | The assumed-role session name (e.g., `AWSLF-…`) appears in the `userIdentity` ARN, enabling correlation with `GetDataAccess` events | The assumed-role session name appears in the Requester field, enabling the same correlation when the request was made under the LF-vended session |
+| **Setup complexity** | Configure a trail with advanced event selectors targeting the relevant buckets or prefixes | Enable server access logging on the source bucket, directing logs to a separate target bucket |
+
+> **Note on session-name correlation:** The join to Lake Formation events works when S3 access is performed under the credentials vended by Lake Formation. In that case the assumed-role session name begins with `AWSLF-` and is the key shared between the Lake Formation `GetDataAccess` event and the S3 audit record.
+
+## Recommendation
+
+!!! tip
+    Use **CloudTrail S3 Data Events scoped with advanced event selectors** as the primary auditing mechanism. Limiting selectors to the S3 locations registered with Lake Formation, and to the specific operations you need (`GetObject`, `PutObject`, `DeleteObject`), keeps costs manageable while giving you near-real-time, structured, complete records that correlate cleanly with Lake Formation events.
+
+    **S3 Server Access Logs** are a suitable lower-cost alternative for very high-volume buckets where per-event CloudTrail charges would be prohibitive. Accept the trade-offs: logs are best-effort, can be delayed by hours, and the space-delimited format requires more parsing work. They are not a substitute for CloudTrail when you need reliable, timely audit trails.
+
+## Controlling CloudTrail data event cost
+
+CloudTrail data events are billed by volume, so scoping them carefully is important in data lake environments where S3 activity can be high.
+
+Use **advanced event selectors** to control what is captured:
+
+- **Limit to relevant resources** — specify the S3 bucket ARNs (or ARN prefixes) for buckets registered with Lake Formation. There is no reason to capture events for buckets outside your governed data lake.
+- **Limit to relevant operations** — include `GetObject` and `PutObject` for read/write auditing, and `DeleteObject` if deletion auditing is required. Add `ListBucket` (via management read events) only if bucket-listing visibility is needed.
+- **Use `readOnly` / `writeOnly` filters** — the `readOnly` field in an advanced event selector lets you capture only read events or only write events, avoiding double-billing for mixed workloads where you need only one direction.
+- **Narrow by key prefix** — if your registered data locations use a consistent prefix structure (for example `s3://my-data-lake/governed/`), scope the `resources.ARN` condition to that prefix.
+
+For the selector syntax, see [CloudTrail advanced event selectors](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-data-events-with-advanced-event-selectors.html).
+
+## Enabling S3 auditing
+
+- **CloudTrail S3 data events** — [Enable CloudTrail logging for S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-cloudtrail-logging-for-s3.html)
+- **CloudTrail advanced event selectors** (for filtering and cost control) — [Logging data events with advanced event selectors](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-data-events-with-advanced-event-selectors.html)
+- **S3 Server Access Logging** — [Amazon S3 server access logging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html)
+
+---
+
+To correlate these S3 records with Lake Formation authorization events, see [Querying Audit Data](querying-audit-data.md).

--- a/content/index.md
+++ b/content/index.md
@@ -7,3 +7,4 @@ This guide is broken down in topics:
 - [Best Practices when adopting Lake Formation](adopting-lake-formation/overview.md)
 - [Best Practices when using Lake Formations data sharing feature](data-sharing/overview.md)
 - [Best Practices when using LF-Tags](lf-tags/overview.md)
+- [Best Practices for auditing data access in Lake Formation](auditing/overview.md)

--- a/docs/superpowers/plans/2026-07-14-auditing-section.md
+++ b/docs/superpowers/plans/2026-07-14-auditing-section.md
@@ -1,0 +1,282 @@
+# Auditing Section Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a new top-level "Auditing" section (four mkdocs pages) to the Lake Formation Best Practices site, teaching readers to build end-to-end audit trails by joining Lake Formation `GetDataAccess` CloudTrail events with S3 access records.
+
+**Architecture:** Four prose markdown pages under `content/auditing/`, following the existing folder+overview convention. Wired into `mkdocs.yml` nav after LF-Tags and linked from `content/index.md`. All CloudTrail/S3 examples are scrubbed with placeholder values. One mermaid diagram on the querying page.
+
+**Tech Stack:** mkdocs 1.6.0 + mkdocs-material, run from `.venv`. Verification is `mkdocs build --strict` (catches broken links/nav) plus manual scrub/content checks.
+
+**Spec:** `docs/superpowers/specs/2026-07-14-auditing-section-design.md`
+
+---
+
+## Conventions For Every Task
+
+- **Activate venv first** in each build command: `source .venv/bin/activate`.
+- **Verification command** (the "test"): `mkdocs build --strict` must exit 0. `--strict` turns broken internal links and nav warnings into errors, so it is our failing/passing signal.
+- **Scrubbing rules** (apply to ALL examples):
+  - AWS account ID → `111122223333`
+  - S3 bucket → `amzn-s3-demo-bucket`
+  - `accessKeyId` → `AKIAIOSFODNN7EXAMPLE`
+  - Principal IDs (`AROA…`), STS session suffixes → short example values (e.g. `AROAEXAMPLEID`, `:EXAMPLE-SESSION`)
+  - Request IDs / event IDs / `x-amz-id-2` → example UUIDs / `EXAMPLE...`
+  - IP addresses → keep AWS service endpoints as-is (`athena.amazonaws.com` etc.); replace real customer IPs (e.g. `18.218.40.42`) with `203.0.113.10`
+  - Region `us-east-2` kept as-is
+  - Keep engine identifiers as-is: `sourceIPAddress` service endpoints, `platformType`, `requesterService`
+- **Editorial decisions already made:**
+  - s3-audit-events recommendation: recommend **CloudTrail S3 Data Events (bucket/prefix + operation-filtered)** as primary for auditability (clean session-name join, near-real-time); **S3 Server Access Logs** as lower-cost/high-volume alternative.
+  - Athena table names: keep from source queries but scrub account ID to `111122223333`; add a note telling readers to substitute their own table names.
+- **Public doc links to use** (verify they resolve; these are the canonical pages):
+  - LF CloudTrail: `https://docs.aws.amazon.com/lake-formation/latest/dg/logging-using-cloudtrail.html`
+  - CloudTrail S3 data events: `https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-cloudtrail-logging-for-s3.html`
+  - CloudTrail advanced event selectors (filtering): `https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-data-events-with-advanced-event-selectors.html`
+  - S3 Server Access Logging: `https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html`
+  - Athena CloudTrail table setup: `https://docs.aws.amazon.com/athena/latest/ug/cloudtrail-logs.html`
+  - Athena S3 access logs table: `https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-s3-access-logs-to-identify-requests.html`
+
+---
+
+## Task 1: Scaffold folder, nav, and index link
+
+Get the four empty-but-valid pages wired into nav and building strict-clean before writing prose. This locks in structure and gives every later task a passing baseline.
+
+**Files:**
+- Create: `content/auditing/overview.md`
+- Create: `content/auditing/lake-formation-cloudtrail.md`
+- Create: `content/auditing/s3-audit-events.md`
+- Create: `content/auditing/querying-audit-data.md`
+- Modify: `mkdocs.yml` (add Auditing nav block after the `LF-Tags` block)
+- Modify: `content/index.md` (add topic bullet)
+
+- [ ] **Step 1: Create the four pages with a minimal H1 + one-line intro each**
+
+Each file gets a valid H1 so nav resolves. Example for `overview.md`:
+
+```markdown
+# Auditing in Lake Formation
+
+Overview of auditing data access in Lake Formation. *(content added in later tasks)*
+```
+
+Give the other three placeholder H1s: `# Lake Formation CloudTrail Events`, `# Auditing S3 Access`, `# Querying Audit Data`.
+
+- [ ] **Step 2: Add the nav block to `mkdocs.yml`**
+
+Insert directly after the `- 'LF-Tags':` block's last child (`limitations.md`) and before `markdown_extensions:`. Match the existing nav indentation exactly (top-level entries at 2 spaces under `nav:`, children at 4 spaces) — check the surrounding lines in `mkdocs.yml` before inserting:
+
+```yaml
+  - 'Auditing':
+    - 'Overview': 'auditing/overview.md'
+    - 'Lake Formation CloudTrail Events': 'auditing/lake-formation-cloudtrail.md'
+    - 'Auditing S3 Access': 'auditing/s3-audit-events.md'
+    - 'Querying Audit Data': 'auditing/querying-audit-data.md'
+```
+
+- [ ] **Step 3: Add the topic bullet to `content/index.md`**
+
+Append to the bulleted topic list:
+
+```markdown
+- [Best Practices for auditing data access in Lake Formation](auditing/overview.md)
+```
+
+- [ ] **Step 4: Verify strict build passes**
+
+Run: `source .venv/bin/activate && mkdocs build --strict`
+Expected: exit 0, no warnings. Confirms all four pages resolve in nav and the index link is valid.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mkdocs.yml content/index.md content/auditing/
+git commit -m "Scaffold Auditing section: pages, nav, index link"
+```
+
+---
+
+## Task 2: overview.md
+
+**Files:**
+- Modify: `content/auditing/overview.md`
+
+- [ ] **Step 1: Write the overview content**
+
+Sections (prose, match the tone of `data-sharing/overview.md`):
+- Intro paragraph: what this section covers.
+- **Why auditing matters**: validating least-privilege grants, detecting policy drift / anomalous access, compliance evidence, incident forensics.
+- **What Lake Formation auditing adds over IAM alone**: `GetDataAccess` captures the authorization decision + query/engine context (engine, query, principal, resource, FGAC vs FTA) that raw S3 events lack.
+- **The end-to-end picture**: LF authorizes (`GetDataAccess`) → engine assumes a session → S3 objects read; full auditing = joining these.
+- **In this section** — bulleted links to the three sub-pages:
+  - `[Lake Formation CloudTrail Events](lake-formation-cloudtrail.md)`
+  - `[Auditing S3 Access](s3-audit-events.md)`
+  - `[Querying Audit Data](querying-audit-data.md)`
+
+- [ ] **Step 2: Verify strict build passes**
+
+Run: `source .venv/bin/activate && mkdocs build --strict`
+Expected: exit 0 (relative links to sibling pages resolve).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add content/auditing/overview.md
+git commit -m "Add Auditing overview page"
+```
+
+---
+
+## Task 3: lake-formation-cloudtrail.md
+
+The largest page. Build it in two commits: examples first, then field guide + cheat table + notes.
+
+**Files:**
+- Modify: `content/auditing/lake-formation-cloudtrail.md`
+
+**Source examples** (from the provided CloudTrail doc, to be scrubbed per rules): EMR Serverless FTA (table read), EMR Serverless FGAC (table read), EMR on EC2 FTA, EMR on EC2 FGAC, Athena v3 FGAC, Glue ETL FGAC, Redshift Provisioned, Redshift Serverless. Each engine/mode in a ```json fenced block, covering both FTA and FGAC where the engine supports both (per spec).
+
+**Note on EMR on EC2 FTA:** the source doc's EMR-on-EC2 FTA subsection is headers-only (no JSON payload); only the FGAC example has a full event. Do **not** fabricate a CloudTrail event. Instead, present the EMR on EC2 FTA subsection with a one-line note that an FTA `GetDataAccess` event for EMR on EC2 is structurally identical to the EMR Serverless FTA example shown above (same `tableArn` + `LakeFormationTrustedCallerInvocation` shape, differing only in the role ARN / `platformType: EMR_ON_EC2`), so the reader is not left thinking the mode is unsupported. This satisfies the spec's "FTA and FGAC" coverage without inventing data.
+
+- [ ] **Step 1: Write intro + scrubbing legend + per-engine examples**
+
+- Intro: what a `GetDataAccess` event is, `eventSource: lakeformation.amazonaws.com`, that it's a management/read-only event emitted when an integrated engine requests credentials/authorization for a table or data location. Link to LF CloudTrail public doc.
+- **Scrubbing legend** admonition (`!!! note "About these examples"`) with the placeholder table from the spec; state these are sanitized samples.
+- One `### <Engine> — <Mode>` subsection per example above, each with a scrubbed ```json block. For Athena, note FTA is not supported. Keep `platformType`, `requesterService`, and service `sourceIPAddress` values intact.
+
+- [ ] **Step 2: Verify strict build passes**
+
+Run: `source .venv/bin/activate && mkdocs build --strict`
+Expected: exit 0.
+
+- [ ] **Step 3: Scrub audit (manual grep)**
+
+Run: `grep -nE '134851836413|hocanint|ASIA|AROAR6ZOLXH|18\.218\.40\.42' content/auditing/lake-formation-cloudtrail.md`
+Expected: **no matches** (all real values replaced). If any match, fix before committing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add content/auditing/lake-formation-cloudtrail.md
+git commit -m "Add LF CloudTrail page: GetDataAccess examples per engine"
+```
+
+- [ ] **Step 5: Add field-reference table (Identity / Source-engine / Resource)**
+
+Three grouped subsections or one table with a "Group" column. Cover:
+- **Identity**: `userIdentity.arn`, `sessionContext.sessionIssuer.arn`, `additionalEventData.lakeFormationPrincipal`, `additionalEventData.lakeFormationRoleSessionName` (call out: session name is the join key to S3 events).
+- **Source/engine**: `sourceIPAddress`, `userAgent`, `requesterService`, `requestParameters.auditContext.additionalAuditContext.platformType`, `jobIdentifier`.
+- **Resource**: `requestParameters.tableArn` vs `dataLocations`, `permissions`, `supportedPermissionTypes` / `CELL_FILTER_PERMISSION`, `cellLevelSecurityEnforced`. In this subsection explain the **FTA vs FGAC vs direct-S3 signals** (FGAC → `cellLevelSecurityEnforced: true` and/or `CELL_FILTER_PERMISSION`; direct-S3/data-location → `dataLocations` present instead of `tableArn`; `LakeFormationAuthorizedCaller` tag).
+
+- [ ] **Step 6: Add quick-reference engine cheat table + caveats**
+
+- **Cheat table**: columns Engine | `sourceIPAddress` | `userAgent` | `platformType`. Rows for EMR Serverless, EMR on EC2, Athena, Glue ETL, Redshift, Redshift Serverless (values from the examples).
+- **Caveats** (`!!! warning`): Table Direct S3 via LF not supported when FGAC enabled on EMR/Glue; EMR/Glue do not support FTA mode with LF for Iceberg tables.
+
+- [ ] **Step 7: Verify strict build passes**
+
+Run: `source .venv/bin/activate && mkdocs build --strict`
+Expected: exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add content/auditing/lake-formation-cloudtrail.md
+git commit -m "Add LF CloudTrail page: field guide, cheat table, caveats"
+```
+
+---
+
+## Task 4: s3-audit-events.md
+
+**Files:**
+- Modify: `content/auditing/s3-audit-events.md`
+
+- [ ] **Step 1: Write the decision-guide content**
+
+- Framing: to see which S3 objects were actually read, you need S3-level auditing; two options.
+- **Comparison table**: rows for cost model, delivery latency, level of detail, completeness/guarantees, joins to LF via session name, setup complexity; columns "CloudTrail S3 Data Events" vs "S3 Server Access Logs".
+- **Recommendation** (`!!! tip`): CloudTrail S3 Data Events (filtered) as primary for auditability; S3 Server Access Logs as lower-cost/high-volume alternative.
+- **Cost optimization for CloudTrail Data Events**: scope event selectors to specific buckets/prefixes and specific operations (`GetObject`/`PutObject`/`DeleteObject`/`ListBucket`) to control volume/cost. Link to advanced event selectors doc.
+- **Enabling** subsection: links to public docs for enabling both (S3 CloudTrail data events, S3 server access logging).
+
+- [ ] **Step 2: Verify strict build passes**
+
+Run: `source .venv/bin/activate && mkdocs build --strict`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add content/auditing/s3-audit-events.md
+git commit -m "Add S3 audit events page: Data Events vs Access Logs decision guide"
+```
+
+---
+
+## Task 5: querying-audit-data.md
+
+**Files:**
+- Modify: `content/auditing/querying-audit-data.md`
+
+**Source queries** (from the provided doc, scrub account ID in table names to `111122223333`): (1) CloudTrail S3 Data Events joined to LF `GetDataAccess`; (2) S3 Server Access Logs joined to LF `GetDataAccess`.
+
+- [ ] **Step 1: Write intro + both Athena queries at the top**
+
+- Short intro: most customers ETL/stitch S3 access records with LF `GetDataAccess` for end-to-end auditing (scheduled or on-demand); both queries below.
+- Note that readers should substitute their own Athena table names (the ones shown use `111122223333` as the example account).
+- Two ```sql fenced blocks with the full queries (account IDs scrubbed).
+
+- [ ] **Step 2: Add join-logic explanation + mermaid diagram**
+
+- Prose explaining the join: `s3_sts_session_name` (parsed from the S3 event's assumed-role ARN) = `lakeFormationRoleSessionName` from the LF event; how `access_method` (LF vs DIRECT) and `lf_source` (engine) are derived.
+- Mermaid diagram (fenced ```mermaid) showing: `GetDataAccess (LF)` → `AssumeRole session (AWSLF-… session name)` → `S3 GetObject`, and a branch showing direct-S3 access where the session-name linkage is absent.
+
+- [ ] **Step 3: Add limitations admonition + operationalization tips**
+
+- **Limitations** (`!!! warning`): direct S3 access via LF does not populate the LF session name, so those rows cannot be joined back to LF events; note FTA/FGAC caveats affecting log contents.
+- **Operationalization tips**: run the join on a schedule (daily/hourly ETL into a curated table) vs on-demand; partition CloudTrail and Access-Log tables by date to control scan cost.
+
+- [ ] **Step 4: Verify strict build passes**
+
+Run: `source .venv/bin/activate && mkdocs build --strict`
+Expected: exit 0.
+
+- [ ] **Step 5: Scrub audit (manual grep)**
+
+Run: `grep -nE '134851836413|hocanint' content/auditing/querying-audit-data.md`
+Expected: **no matches**.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add content/auditing/querying-audit-data.md
+git commit -m "Add querying audit data page: Athena queries, diagram, limitations"
+```
+
+---
+
+## Task 6: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full strict build**
+
+Run: `source .venv/bin/activate && mkdocs build --strict`
+Expected: exit 0, zero warnings.
+
+- [ ] **Step 2: Repo-wide scrub audit across the new section**
+
+Run: `grep -rnE '134851836413|hocanint|ASIAR6ZOLXH|AROAR6ZOLXH|18\.218\.40\.42' content/auditing/ content/index.md`
+Expected: **no matches**. (The `AROAR6ZOLXH` prefix matches every real principal ID in the source examples.)
+
+- [ ] **Step 3: Confirm nav ordering and mermaid render**
+
+Run: `grep -n "Auditing" mkdocs.yml` and open `site/auditing/querying-audit-data/index.html` to confirm the mermaid block rendered (search for `class="mermaid"`).
+Expected: Auditing block present after LF-Tags; mermaid div present.
+
+- [ ] **Step 4: Final commit if any fixups were needed**
+
+```bash
+git add -A && git commit -m "Finalize Auditing section" || echo "nothing to commit"
+```

--- a/docs/superpowers/specs/2026-07-14-auditing-section-design.md
+++ b/docs/superpowers/specs/2026-07-14-auditing-section-design.md
@@ -1,0 +1,168 @@
+# Design: Auditing Section for Lake Formation Best Practices
+
+**Date:** 2026-07-14
+**Status:** Approved (pending spec review)
+
+## Goal
+
+Add a new top-level **Auditing** section to the AWS Lake Formation Best Practices
+mkdocs site. The section teaches readers how to build end-to-end audit trails for
+data-lake access by combining Lake Formation `GetDataAccess` CloudTrail events with
+S3 access records (CloudTrail S3 Data Events or S3 Access Logs), including sample
+CloudTrail events per engine and ready-to-run Athena queries that stitch the two
+together.
+
+## Context
+
+- Project is an mkdocs (Material theme) site. `docs_dir: content`.
+- Existing sections live in `content/<topic>/` folders, each with an `overview.md`
+  plus topic pages, wired into `nav:` in `mkdocs.yml`.
+- Pages are prose best-practices with admonitions, fenced code blocks (copy enabled),
+  tables, and liberal links to public AWS documentation. Mermaid is available via
+  `pymdownx.superfences`.
+- Source material: an attached document (`Auditing in LF - CloudTrail Examples.pdf`)
+  containing `GetDataAccess` CloudTrail examples for multiple engines in Full Table
+  Access (FTA) and Fine-Grained Access Control (FGAC) modes, S3 CloudTrail and S3
+  Access Log samples, and two full Athena stitching queries.
+
+## Structure
+
+New folder `content/auditing/` with four pages:
+
+```
+content/auditing/
+  overview.md                    # Why audit; what LF + S3 auditing gives you; page map
+  lake-formation-cloudtrail.md   # GetDataAccess events, one example per engine, field guide
+  s3-audit-events.md             # CloudTrail Data Events vs S3 Access Logs — decision guide
+  querying-audit-data.md         # Both Athena queries up top + limitations callout
+```
+
+Nav insertion in `mkdocs.yml`, placed after the `LF-Tags` block:
+
+```yaml
+- 'Auditing':
+  - 'Overview': 'auditing/overview.md'
+  - 'Lake Formation CloudTrail Events': 'auditing/lake-formation-cloudtrail.md'
+  - 'Auditing S3 Access': 'auditing/s3-audit-events.md'
+  - 'Querying Audit Data': 'auditing/querying-audit-data.md'
+```
+
+Add a bullet to `content/index.md`'s topic list linking to `auditing/overview.md`.
+
+## Data Sanitization (applies to every example on every page)
+
+All CloudTrail/S3 examples MUST be scrubbed. A short **scrubbing legend** appears near
+the top of `lake-formation-cloudtrail.md` (and is referenced from other pages) stating
+these are sanitized samples and listing the placeholder conventions:
+
+| Real value type | Placeholder used |
+|---|---|
+| AWS account ID | `111122223333` |
+| S3 bucket name | `amzn-s3-demo-bucket` (AWS-recommended example bucket name) |
+| Access key ID (`accessKeyId`) | redacted / `AKIAIOSFODNN7EXAMPLE`-style example |
+| Principal ID (`AROA...`, `:sessionId`) | shortened example value |
+| Request/event IDs, `x-amz-id-2` | example UUIDs |
+| Region | keep `us-east-2` (not sensitive) |
+| IP addresses | example/service endpoint values |
+
+Applies to: account IDs, bucket names, `accessKeyId`, `principalId`, session names,
+request IDs, `x-amz-id-2`, and IP addresses. Engine/service identifiers
+(`sourceIPAddress` like `athena.amazonaws.com`, `platformType`) are kept as-is because
+they are documented, non-sensitive, and needed for auditing.
+
+## Page Contents
+
+### overview.md
+
+- **Why auditing matters**: validating least-privilege grants, detecting policy drift
+  and anomalous access, producing compliance evidence, incident forensics.
+- **What Lake Formation auditing adds over IAM alone**: `GetDataAccess` captures the
+  *authorization decision* plus query/engine context (which engine, which query,
+  which principal, which resource, FGAC vs FTA) that raw S3 data events lack.
+- **The end-to-end picture**: LF authorizes (`GetDataAccess`) → engine assumes a
+  session → S3 objects are read. Full auditing means joining these.
+- **Page map** linking the three sub-pages.
+
+### lake-formation-cloudtrail.md
+
+- Explanation of the `GetDataAccess` event: what triggers it, `eventSource:
+  lakeformation.amazonaws.com`, that it is a management/read event.
+- **Scrubbing legend** (table above).
+- **One scrubbed example per engine**, in FTA and FGAC where the engine supports both:
+  - EMR Serverless — FTA (table read) and FGAC (table read)
+  - EMR on EC2 — FTA and FGAC
+  - Athena (v3) — FGAC (note: FTA not supported)
+  - Glue ETL — FGAC
+  - Redshift Provisioned
+  - Redshift Serverless
+- **Field-reference table** grouped into three areas the reader needs for auditing:
+  - **Identity**: `userIdentity.arn`, `userIdentity.sessionContext.sessionIssuer.arn`,
+    `additionalEventData.lakeFormationPrincipal`,
+    `additionalEventData.lakeFormationRoleSessionName` (call out that the session name
+    is the join key to S3 events).
+  - **Source/engine**: `sourceIPAddress`, `userAgent`, `requesterService`,
+    `requestParameters.auditContext.additionalAuditContext.platformType`,
+    `jobIdentifier`.
+  - **Resource**: `requestParameters.tableArn` vs `requestParameters.dataLocations`,
+    `permissions` (e.g. `SELECT`), `supportedPermissionTypes` /
+    `CELL_FILTER_PERMISSION`, `cellLevelSecurityEnforced`. The **FTA vs FGAC vs
+    direct-S3 signals** are explained here (FGAC → `cellLevelSecurityEnforced: true`
+    and/or `CELL_FILTER_PERMISSION`; direct-S3/data-location access → `dataLocations`
+    present instead of `tableArn`; `LakeFormationAuthorizedCaller` tag).
+- **Quick-reference cheat table**: each engine → its `sourceIPAddress` / `userAgent` /
+  `platformType` signature, so a reader can identify the producing engine from a log line.
+- **Notes/caveats** from source doc: Table Direct S3 via LF is not supported when FGAC
+  is enabled on EMR/Glue; EMR/Glue do not support FTA mode with LF for Iceberg tables.
+
+### s3-audit-events.md
+
+- Framing: to see which S3 objects were actually read you need S3-level auditing;
+  two options exist.
+- **Decision-guide comparison table**: CloudTrail S3 Data Events vs S3 Server Access
+  Logs across: cost model, latency/delivery time, level of detail, completeness/
+  guarantees, ability to join to LF via session name, setup complexity.
+- **Recommendation**: state a clear "use X when…" recommendation.
+- **Cost optimization for CloudTrail Data Events**: you can scope a data event
+  selector to specific buckets/prefixes and to specific S3 operations
+  (`GetObject`/`PutObject`/`DeleteObject`/`ListBucket`) to keep volume and cost low.
+- Links to public docs for enabling both mechanisms.
+
+### querying-audit-data.md
+
+- **Both Athena queries at the top of the page**:
+  1. CloudTrail S3 Data Events joined to LF `GetDataAccess`.
+  2. S3 Server Access Logs joined to LF `GetDataAccess`.
+- Brief explanation of the **join logic**: `s3_sts_session_name` (parsed from the S3
+  event's assumed-role ARN) = `lakeFormationRoleSessionName` from the LF event; how
+  `access_method` (LF vs DIRECT) and `lf_source` (engine) are derived.
+- **Session-name linkage mermaid diagram**: `GetDataAccess` → assumed session
+  (`AWSLF-…` session name) → S3 `GetObject`, showing where linkage exists and where it
+  breaks for direct-S3 access.
+- **Prominent limitations admonition** (`!!! warning`): direct S3 access via LF does
+  not populate the LF session name, so those rows cannot be joined back to LF events;
+  plus the FTA/FGAC caveats affecting what appears in the logs.
+- **Operationalization tips**: run the join on a schedule (daily/hourly ETL into a
+  curated table) vs on-demand; partition CloudTrail and Access-Log tables by date to
+  control scan cost.
+
+## Enhancements Included
+
+1. Scrubbing legend (in `lake-formation-cloudtrail.md`, referenced elsewhere).
+2. Operationalization tips (in `querying-audit-data.md`).
+3. Session-name linkage mermaid diagram (in `querying-audit-data.md`).
+4. Quick-reference engine cheat table (in `lake-formation-cloudtrail.md`).
+
+## Out of Scope (YAGNI)
+
+- No new images/screenshots beyond the one mermaid diagram.
+- No reproduction of every raw JSON blob from the PDF — one representative example per
+  engine/mode only.
+- No changes to existing sections.
+- No automation/scripts for log setup — link to public docs instead.
+
+## Testing / Verification
+
+- `mkdocs build` succeeds with no warnings about the new pages or nav entries.
+- All internal links resolve; all four pages appear in nav in the intended order.
+- Spot-check that no real account IDs, bucket names, access keys, or principal IDs
+  from the source doc remain in any example.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,11 @@ nav:
     - 'Best Practices': 'lf-tags/best-practices.md'
     - 'Example Usecase': 'lf-tags/example-usecase.md'
     - 'Limitations': 'lf-tags/limitations.md'
+  - 'Auditing':
+    - 'Overview': 'auditing/overview.md'
+    - 'Lake Formation CloudTrail Events': 'auditing/lake-formation-cloudtrail.md'
+    - 'S3 Audit Events': 'auditing/s3-audit-events.md'
+    - 'Querying Audit Data': 'auditing/querying-audit-data.md'
 markdown_extensions:
   - toc:
       permalink: true


### PR DESCRIPTION
## Add Auditing section to Lake Formation Best Practices

### What & why

Adds a new top-level **Auditing** section to the guide. Lake Formation governs *authorization*, but auditing "who actually accessed which data" requires correlating Lake Formation's `GetDataAccess` CloudTrail events with the underlying S3 access records. This section documents how to capture both signals and stitch them together for end-to-end audit trails — something not covered anywhere else in the guide today.

### What's included

Four pages under `content/auditing/`:

- **Overview** — why auditing matters (validating least-privilege, detecting drift/anomalies, compliance evidence, incident forensics), what Lake Formation auditing adds over IAM alone, and the end-to-end authorize → session → S3 access picture.
- **Lake Formation CloudTrail Events** — explains the `GetDataAccess` event with one sanitized example per engine (EMR Serverless, EMR on EC2, Athena, Glue ETL, Redshift, Redshift Serverless) in Full Table Access and Fine-Grained Access Control modes; a field reference grouped by identity / source-engine / resource; a quick-reference table for identifying the calling engine; how to tell FTA vs FGAC vs direct-S3 apart; and access-mode caveats.
- **S3 Audit Events** — a decision guide comparing CloudTrail S3 Data Events vs S3 Server Access Logs (cost, latency, detail, completeness, join-ability, setup), a recommendation, and guidance on scoping CloudTrail data events with advanced event selectors to control cost.
- **Querying Audit Data** — two annotated Athena queries (CloudTrail-based and Access-Log-based) that join S3 access to Lake Formation events on the `AWSLF-` session name, a mermaid diagram of the join, a sanitized sample output, the direct-S3 join limitation, and operationalization tips.

Wired into the mkdocs nav after LF-Tags and linked from the index page.

### Notes for reviewers

- **All examples are sanitized** — account IDs → `111122223333`, buckets → `amzn-s3-demo-bucket`, and access keys / principal IDs / request IDs / session names / IPs replaced with placeholders. A scrubbing legend on the CloudTrail page documents the conventions.
- **The engine-to-S3 mapping query is the centerpiece** of the section — it's what turns raw logs into "which principal, via which engine, read which object."
- `mkdocs build --strict` passes with no warnings.
