### PR TITLE
docs: add data masking with Glue views and entitlement table pattern

### DIFF
--- a/content/advanced-access-control-patterns/data-masking/glue-views-entitlement-table.md
+++ b/content/advanced-access-control-patterns/data-masking/glue-views-entitlement-table.md
@@ -1,0 +1,116 @@
+# Masking View with an Entitlement Table
+
+This page covers Approach 3 from the [data masking overview](overview.md). It extends the [masking view](masking-view.md) with one change: instead of masking every reader identically, the view joins an entitlement table keyed on the caller's identity and decides per principal which columns to reveal.
+
+Reach for it when a single view has to serve principals with different rights, or when entitlements change often enough that editing a table beats issuing a grant. If every restricted reader should see the same masked output, the simpler fixed-masking view is the better choice.
+
+These are Data Catalog views, also called multi-dialect views, and they are not materialized views: nothing is precomputed or stored. A Data Catalog view is a stored query definition the engine resolves and re-executes on every read, which is what lets the masking depend on who is running the query at that moment.
+
+!!! note
+
+    This pattern reads the caller's identity with `invoker_principal()`, which exists only in Athena engine version 3. Data Catalog views themselves can be read from Redshift and Spark as well, but those engines have no equivalent caller-identity function, so a query against this view from anywhere other than Athena cannot resolve who is asking. Restrict the view to Athena consumers. If a consumer must read the data through Redshift, EMR, or Glue, give it a [masking view](masking-view.md) with fixed masking, or [precomputed masking](precomputed-masking.md).
+
+## The three roles
+
+Three principals participate, and Lake Formation permissions land on each differently:
+
+- **Lake Formation Admin.** Configures the Lake Formation permissions that make the rest of this work: the Definer's grantable `SELECT` on the base tables, and the Invokers' `SELECT` on the view.
+- **Definer.** The IAM role that creates the view. It must hold full, grantable `SELECT` on every table the view definition references, because Lake Formation checks the Definer's permissions, not the Invoker's, when the view runs. The Definer must be an IAM role, not a user or group, and its trust policy must allow `sts:AssumeRole` for the AWS Glue and Lake Formation service principals.
+- **Invoker.** Any principal the Lake Formation Admin grants `SELECT` on the view itself, after the view exists. `DataEngineerRole` and `MarketingAnalystRole` are both Invokers of `sales.customers_masked` in this example. Neither needs any permission on `sales.customers`: the Invoker queries the view and never touches the base table's grants.
+
+That last point is the security property the whole pattern rests on: querying `customers_masked` requires no permission on `customers`.
+
+!!! warning
+
+    That property only holds if it is the only path to the data. If an Invoker also holds `SELECT` on `sales.customers` directly, the masking is decorative: the Invoker can bypass the view and query the base table for raw values whenever it wants. Revoke base-table access from every persona this pattern is meant to mask, `MarketingAnalystRole` included, and check that no LF-Tag expression or database-level grant reopens it later.
+
+## `invoker_principal()`
+
+`invoker_principal()` returns a `VARCHAR` containing the ARN of the principal that ran the query calling it. That principal is an IAM role or an Identity Center identity. The role running the query must allow the `lakeformation:GetDataLakePrincipal` action, or the call fails.
+
+The returned ARN is the role ARN, not the STS assumed-role ARN:
+
+```text
+Returned by invoker_principal():  arn:aws:iam::111122223333:role/MarketingAnalystRole
+NOT returned (assumed-role form): arn:aws:sts::111122223333:assumed-role/MarketingAnalystRole/session-name
+```
+
+That distinction is what makes the entitlement table workable. The role ARN is stable across every session a principal opens, so the entitlement table keys on one row per principal, not one row per session. Key it on the assumed-role form instead and every new session mints a session name the table has never seen, and every join misses.
+
+## Entitlement table
+
+`sales.pii_entitlements` holds one row per principal:
+
+| `principal_arn` | `role_name` | `can_see_pii` | `can_see_name` | `can_see_email` | `can_see_ssn` |
+|---|---|---|---|---|---|
+| `arn:aws:iam::111122223333:role/DataEngineerRole` | `DataEngineerRole` | `true` | `true` | `true` | `true` |
+| `arn:aws:iam::111122223333:role/MarketingAnalystRole` | `MarketingAnalystRole` | `false` | `false` | `false` | `false` |
+
+Two granularities are available at once. `can_see_pii` is a single flag for an all-or-nothing split: entitled or not, with no distinction between `name`, `email`, and `ssn`. The three `can_see_*` columns split that further, so one principal could see `name` but not `ssn`. The view definition below joins on the per-column flags. `role_name` exists for whoever reads the table; the join key is `principal_arn`, and `role_name` never appears in the view's `WHERE` or `JOIN` clauses.
+
+## View definition
+
+```sql
+CREATE OR REPLACE PROTECTED MULTI DIALECT VIEW sales.customers_masked
+SECURITY DEFINER
+AS
+SELECT
+    c.customer_id,
+    CASE WHEN COALESCE(e.can_see_name, false)
+         THEN c.name
+         ELSE to_hex(sha256(to_utf8(c.name))) END     AS name,
+    CASE WHEN COALESCE(e.can_see_email, false)
+         THEN c.email
+         ELSE concat(substr(split_part(c.email, '@', 1), 1, 1),
+                     '***@', split_part(c.email, '@', 2)) END AS email,
+    CASE WHEN COALESCE(e.can_see_ssn, false)
+         THEN c.ssn ELSE NULL END                     AS ssn,
+    c.city,
+    c.country,
+    c.loyalty_tier
+FROM sales.customers c
+LEFT JOIN sales.pii_entitlements e
+       ON e.principal_arn = invoker_principal()
+```
+
+`SECURITY DEFINER` is required syntax for a Data Catalog view. `UNPROTECTED` Data Catalog views are not supported either, so `PROTECTED` is not optional.
+
+The `LEFT JOIN` is deliberate. A principal with no row in `pii_entitlements` produces `NULL` for every `can_see_*` column, `COALESCE` turns each `NULL` into `false`, and every `CASE` branch falls to the masked output. A new hire who has not yet been added to the entitlement table sees masked values by default, not raw ones. The pattern fails closed.
+
+This is Athena SQL, specifically the Trino dialect, so the function names differ from the PySpark jobs on the [precomputed masking](precomputed-masking.md) page even though the masking rules are identical. Two differences are worth calling out, because both are easy to get wrong when porting an expression between the two:
+
+| Rule | PySpark | Athena SQL (Trino) |
+|---|---|---|
+| Hash `name` | `sha2(col("name"), 256)` | `to_hex(sha256(to_utf8(c.name)))` |
+| Split `email` | `split(col("email"), "@").getItem(0)` | `split_part(c.email, '@', 1)` |
+
+Trino has no `sha2` function. Its `sha256` takes `varbinary` and returns `varbinary`, so the column has to be encoded with `to_utf8` on the way in and rendered with `to_hex` on the way out; skipping either one is a type error at view creation. Trino's `split_part` is also 1-indexed, where PySpark's `getItem` starts at 0.
+
+Before running the `CREATE OR REPLACE` above against a real environment, append `SHOW VIEW JSON` to the same statement to dry-run it: Athena validates the definition and, if it is valid, returns the Glue table JSON that would represent the view, without creating anything.
+
+## Operational notes
+
+`sales.pii_entitlements` is an access-control policy stored as data, not a data table. Restrict it in Lake Formation the same way you would restrict a grant, and do not grant Invoker principals `SELECT` on it: they need no access to it, since the Definer's permissions are what let the view's join run.
+
+Adding a person is an `INSERT` into that table, not a Lake Formation grant. That is the pattern's main convenience, and its main audit gap. Lake Formation's [audit trail](../../auditing/lake-formation-cloudtrail.md) records `GetDataAccess` events for the view being read; it does not record which branch of the `CASE` expression a given query hit, so those events will not tell you who saw a raw `ssn` on a given day. If that evidence matters, version or log changes to `pii_entitlements` separately.
+
+The documented constraints on Data Catalog views bind this pattern specifically:
+
+- A view definition can reference up to 10 tables, and `pii_entitlements` counts as one of them alongside `customers` and anything else joined in.
+- The view cannot reference other views, database resource links, or table resource links.
+- Base tables must not carry the `IAMAllowedPrincipals` permission; if one does, the view fails with `Multi Dialect views may only reference tables without IAMAllowedPrincipals permissions`.
+- Every base table's S3 location must be registered as a Lake Formation data lake location, or the view fails with `Multi Dialect views may only reference Lake Formation managed tables`.
+- UDFs are not supported in the view definition, which is why the masking above uses built-in functions (`to_hex`, `sha256`, `to_utf8`, `concat`, `substr`, `split_part`) rather than a custom function.
+- Tables in Amazon S3 table buckets (S3 Tables) are not supported as base tables, so neither `customers` nor `pii_entitlements` can live in one.
+
+For the current list, see [Data Catalog views considerations and limitations](https://docs.aws.amazon.com/lake-formation/latest/dg/views-notes.html) in the Lake Formation Developer Guide, plus the [Athena-specific limitations](https://docs.aws.amazon.com/athena/latest/ug/views-glue.html#views-glue-limitations).
+
+## Trade-offs
+
+No duplicated data: one table, one view, no second copy of `customers` to keep in sync. No ETL job to schedule or monitor. Both personas see the same column names, so one query definition works for both. Entitlement changes take effect on the next query, since there is nothing to re-run or re-deploy.
+
+The costs run the other way. Readers must be on Athena, because `invoker_principal()` exists nowhere else, which makes this the only approach here with a hard engine restriction. Part of the authorization model also moves out of Lake Formation grants and into `pii_entitlements` as data, so answering "who can see the real `ssn`" means reading a table in addition to reading Lake Formation grants.
+
+This is also the most expensive of the three at read time. [Precomputed masking](precomputed-masking.md) pays once per ETL run and stores the result, so its readers pay nothing; a [fixed masking view](masking-view.md) evaluates masking expressions per query; this pattern does that and adds a join to `pii_entitlements` plus an `invoker_principal()` call on top. The extra work repeats on every query rather than per ETL run, adding scanned bytes on engines billed that way and compute time on the others. A view over a large table queried a few times a day is cheap by comparison; the same view behind dashboards refreshing all day may not be. Keeping `pii_entitlements` small enough for the engine to broadcast it limits the join cost, though the per-row `CASE` evaluation remains either way.
+
+Take the per-principal masking only if you need it. If every restricted reader can see the same masked values, a [fixed masking view](masking-view.md) delivers that outcome without the join, the entitlement table, or the Athena restriction.

--- a/content/advanced-access-control-patterns/data-masking/masking-view.md
+++ b/content/advanced-access-control-patterns/data-masking/masking-view.md
@@ -1,0 +1,109 @@
+# Masking View
+
+This page covers Approach 2 from the [data masking overview](overview.md): a Glue Data Catalog view selects from `sales.customers` and applies the masking in its `SELECT` list. Lake Formation grants the view to the restricted persona and the base table to the privileged one. No pipeline runs, and nothing is stored.
+
+It produces the same masked output as [precomputed masking](precomputed-masking.md) without the ETL job, without a second copy of the data, and without a staleness window, because the masking is applied to current data every time the view is read.
+
+The column names inside the view match the table, so the body of an existing query keeps working, but the object it selects **from** changes: the restricted persona has to query `sales.customers_masked` rather than `sales.customers`. Anything already reading the raw table needs that edit, so inventory the dashboards, saved queries, BI datasets, and jobs involved before switching a persona over.
+
+## Two objects, two grants
+
+The design has one table and one view:
+
+- `sales.customers`, the raw table, granted to `DataEngineerRole`.
+- `sales.customers_masked`, a Data Catalog view over it, granted to `MarketingAnalystRole`.
+
+The view carries the same seven column names as the table, with `name`, `email`, and `ssn` masked in its definition. Nothing about `sales.customers` changes, so existing consumers of the raw table are unaffected by adding the view.
+
+`MarketingAnalystRole` needs no permission on `sales.customers`. That is the property the whole approach depends on, and it comes from definer semantics: the view runs with the permissions of the role that created it, not the role querying it.
+
+## Definer semantics
+
+Three principals participate, and Lake Formation permissions land on each differently:
+
+- **Lake Formation Admin.** Configures the permissions the rest of this needs: the Definer's grantable `SELECT` on `sales.customers`, and the Invoker's `SELECT` on the view.
+- **Definer.** The IAM role that creates the view. It must hold full, grantable `SELECT` on every table the definition references, because the engine uses the Definer's permissions to read those tables when the view runs. The Definer must be an IAM role, and its trust policy must allow `sts:AssumeRole` for the AWS Glue and Lake Formation service principals.
+- **Invoker.** Any principal granted `SELECT` on the view. `MarketingAnalystRole` is the Invoker here, and it queries `customers_masked` without any grant on `customers`.
+
+!!! warning
+
+    The masking holds only if the view is the only path to the data. If `MarketingAnalystRole` also holds `SELECT` on `sales.customers`, whether from a leftover grant, a database-level grant on `sales`, or `IAMAllowedPrincipals` left enabled, it can bypass the view and read raw values directly. Revoke base-table access from every persona this view is meant to mask, and re-check effective permissions whenever another grant touches `sales.customers`.
+
+## View definition
+
+```sql
+CREATE OR REPLACE PROTECTED MULTI DIALECT VIEW sales.customers_masked
+SECURITY DEFINER
+AS
+SELECT
+    customer_id,
+    to_hex(sha256(to_utf8(name)))                  AS name,
+    concat(substr(split_part(email, '@', 1), 1, 1),
+           '***@', split_part(email, '@', 2))       AS email,
+    CAST(NULL AS VARCHAR)                           AS ssn,
+    city,
+    country,
+    loyalty_tier
+FROM sales.customers
+```
+
+Every keyword in the first two lines is required. `PROTECTED` is mandatory because Data Catalog views cannot be created any other way, and `SECURITY DEFINER` is what puts definer semantics in force. `OR REPLACE` updates an existing view, though it fails if dialects from other engines are present in the view; more on that below.
+
+`ssn` is cast to `VARCHAR` rather than written as a bare `NULL` so the view's column type is declared rather than inferred. For the last-4 variant instead of full redaction, replace that line with:
+
+```sql
+concat('***-**-', substr(ssn, -4))                  AS ssn,
+```
+
+Append `SHOW VIEW JSON` to the statement to dry-run it. Athena validates the definition and returns the Glue table JSON it would create, without creating anything.
+
+The masking expressions here are Trino syntax, because the view is being created from Athena. Trino has no `sha2` function; its `sha256` takes and returns `varbinary`, so the value is encoded with `to_utf8` going in and rendered with `to_hex` coming out. Skipping either is a type error at creation time. Compare the PySpark form on the [precomputed masking](precomputed-masking.md) page, which expresses the identical rule as `sha2(col("name"), 256)`.
+
+## Granting the view
+
+Grant `SELECT` on the view exactly as you would on a table. The Invoker gets nothing on `sales.customers`.
+
+```bash
+aws lakeformation grant-permissions \
+  --principal DataLakePrincipalIdentifier=arn:aws:iam::111122223333:role/MarketingAnalystRole \
+  --permissions "SELECT" \
+  --resource '{"Table": {"CatalogId": "111122223333", "DatabaseName": "sales", "Name": "customers_masked"}}'
+```
+
+LF-Tags work on views too, so tagging the view `Sensitivity=Masked` and the base table `Sensitivity=PII` lets one tag expression per persona cover both objects, which scales better once several masked views exist.
+
+## Reading the view from more than one engine
+
+Data Catalog views are multi-dialect, and this is where the "MULTI DIALECT" keyword earns its place. Amazon Redshift, Athena engine version 3, Apache Spark on EMR Serverless, and Apache Spark on AWS Glue 5.0 all support Data Catalog views, so a view created from Athena can be read from the others.
+
+The catch is that each engine reads its own SQL dialect. Creating the view from Athena stores a Trino-dialect definition, and `to_hex(sha256(to_utf8(...)))` is Trino syntax. To serve a Redshift consumer, add a Redshift-dialect definition to the same view with `ALTER VIEW`, expressing the same masking in Redshift SQL. Every dialect must reference the same tables, columns, and data types, so the dialects differ in function names while the view's schema stays fixed.
+
+Plan for that before choosing this approach for a mixed-engine estate: one masking rule now has one definition per engine to keep in agreement. A single-engine estate never encounters the problem, and [precomputed masking](precomputed-masking.md) avoids it entirely by storing values that any engine can read without a dialect.
+
+## Limitations
+
+The documented constraints on Data Catalog views apply:
+
+- A view definition can reference up to 10 tables.
+- Views cannot reference other views, database resource links, or table resource links.
+- Base tables must not carry the `IAMAllowedPrincipals` permission, or the view fails with `Multi Dialect views may only reference tables without IAMAllowedPrincipals permissions`.
+- Every base table's S3 location must be registered as a Lake Formation data lake location, or the view fails with `Multi Dialect views may only reference Lake Formation managed tables`.
+- UDFs are not supported in the definition, so the masking must be expressible in the engine's built-in functions.
+- Tables in Amazon S3 table buckets (S3 Tables) are not supported as base tables. A table in a table bucket has to be masked another way, such as [precomputed masking](precomputed-masking.md).
+- Athena reports an error for stale views, which happens when the view references tables or databases that no longer exist, when a referenced table's schema or metadata changes, or when a referenced table is dropped and recreated with a different schema. A column added to `sales.customers` does not appear in the view until the definition is updated.
+
+For the current list, see [Data Catalog views considerations and limitations](https://docs.aws.amazon.com/lake-formation/latest/dg/views-notes.html) in the Lake Formation Developer Guide, plus the engine-specific limitations for [Athena](https://docs.aws.amazon.com/athena/latest/ug/views-glue.html#views-glue-limitations) and [Redshift](https://docs.aws.amazon.com/redshift/latest/dg/data-catalog-views-overview.html#data-catalog-views-considerations).
+
+## Cost and performance
+
+Nothing is stored and no pipeline runs, so this approach has no write-side cost. Each query against the view scans `sales.customers` and evaluates the masking expressions on the rows it returns, which is compute the reader pays for on every query.
+
+That cost is smaller than the [entitlement table approach](glue-views-entitlement-table.md), which adds a join to the same work, and larger than [precomputed masking](precomputed-masking.md), where the values are already materialized and the reader pays nothing. For most workloads the difference is minor next to the base table scan; for a table under constant dashboard load, measure it before assuming so.
+
+## Trade-offs
+
+No ETL, no duplicated data, no staleness window, and readers see current values with the same column names the raw table uses, so one query definition works against either object. Adding a masked view to an existing table changes nothing about that table.
+
+The masking is fixed in the view definition, which is the main limitation. Every Invoker of `customers_masked` sees the same masked output; there is no per-principal variation. Two personas needing different masking need two views, and N sensitivity levels need N views. If entitlements must vary per principal, or change without a redefinition, use [Masking view with an entitlement table](glue-views-entitlement-table.md), which keys the masking off the caller's identity at query time.
+
+The other costs are the dialect work in a mixed-engine estate, and that the view must remain the only path to the data for the masking to mean anything.

--- a/content/advanced-access-control-patterns/data-masking/overview.md
+++ b/content/advanced-access-control-patterns/data-masking/overview.md
@@ -1,0 +1,171 @@
+# Data Masking in Lake Formation
+
+## What data masking is
+
+Data masking replaces a sensitive value with a substitute that is safe for a wider audience, while leaving the column itself in place. For example, a social security number could return `NULL`, an email address returns `j***@example.com`, a customer name returns a hash. The column still exists, still has a name and a type, and still appears in the result set. 
+
+Teams reach for masking when one dataset has to serve audiences with different rights to it. A marketing analyst needs to segment customers by loyalty tier and country, and needs a `customers` table to do it, but has no business reason to read anyone's social security number. Masking lets that analyst query the same table as the engineer who does have that right, without a curated extract per audience and without the raw value ever reaching the analyst's result set. It also keeps existing queries and dashboards working, because the shape of the data does not change. Deterministic masking goes further: a hashed `name` still joins and groups correctly, so aggregate work continues to produce the right answers over values nobody can read.
+
+## Data masking using Glue Data Catalog and Lake Formation
+
+Lake Formation's grant model decides *whether* a column is returned to a caller. It does not decide *what value* comes back in a column that is returned. There is no grant, LF-Tag, or data filter that says "return this column, but transform its contents first." A column that is granted comes back with the value stored in the table.
+
+That is a functional gap rather than a design position, and it is the reason this sub-topic exists. Until Lake Formation offers masking as a first-class feature, the transformation has to happen somewhere else: computed ahead of time by a pipeline and stored, or applied at query time by a view in front of the table. Three approaches cover the useful combinations, and they differ mainly in when the masking runs and whether it varies per caller.
+
+### Approach 1: precomputed masking with Glue ETL
+
+```mermaid
+flowchart LR
+    A[Source table] --> B[Glue ETL job]
+    B --> C[Masked values stored]
+    C --> D[Privileged role]
+    C --> E[Restricted role]
+```
+
+A Glue ETL job computes the masked values ahead of time and writes them to storage. Lake Formation grants then decide which stored copy each persona reads. Two designs share this shape: the job either adds masked columns beside the raw ones in the same table, split by column-level LF-Tag grants, or writes a separate masked table, split by table-level grants. Either way the masking is materialized before anyone queries it.
+
+### Approach 2: masking view
+
+```mermaid
+flowchart LR
+    A[Raw table] --> B[Data Catalog view]
+    A --> D[Privileged role]
+    B --> E[Restricted role]
+```
+
+A Glue Data Catalog view selects from the raw table and applies the masking in its `SELECT` list. The privileged persona is granted the table; the restricted persona is granted only the view, and needs no permission on the table underneath it. No pipeline runs and nothing is stored, so readers always see current data. Every reader of the view sees the same masked values.
+
+### Approach 3: masking view with an entitlement table
+
+```mermaid
+flowchart LR
+    A[Raw table] --> B[Data Catalog view]
+    G[Entitlement table] --> B
+    B --> D[Privileged role]
+    B --> E[Restricted role]
+```
+
+The same view, with the masking decided per caller instead of fixed. The view joins an entitlement table keyed on the identity returned by `invoker_principal()`, so one view serves principals with different rights and both personas query the same object. Adding or changing someone's entitlements is a row edit rather than a grant change.
+
+## Comparing the three approaches
+
+Read this table alongside the implementation pages rather than instead of them; each page explains its own trade-offs in more detail.
+
+| Dimension | Approach 1: precomputed with Glue ETL | Approach 2: masking view | Approach 3: masking view with entitlement table |
+|---|---|---|---|
+| Engine support | Any engine honoring LF grants | Athena, Redshift, Spark on EMR Serverless, Spark on Glue 5.0 | Athena only, because `invoker_principal()` exists only there |
+| ETL required | Yes | No | No |
+| Data duplication | Masked columns, or a second table | None | None |
+| Freshness | As fresh as the last ETL run | Always current | Always current |
+| Masking varies per caller | No | No | Yes |
+| Changing who sees what | Re-grant permissions | Redefine the view, or grant a different view | Edit a row in the entitlement table |
+| Column names stable across personas | Same-table variant: no. Separate-table variant: yes | Yes | Yes |
+| Impact on existing consumers | Queries must change: a new column name, or a new table name | Queries must change: a new object in the `FROM` clause | None; both personas keep querying the same object |
+| Storage cost | One extra column per masked column, or a full second copy | None | None |
+| Query cost | None beyond the table scan; masked values are materialized | Masking expressions evaluated per query | Masking expressions plus an entitlement join per query |
+| Operational surface | A Glue job, plus LF-Tag or table grants | One view definition per masking scheme, one per dialect if multi-engine | A view definition plus an entitlement table to maintain and protect |
+| Where enforcement lives | Lake Formation grants | The view definition, with Lake Formation granting the view | The view definition plus the entitlement table, with Lake Formation granting the view |
+
+Data Catalog views are readable from Amazon Redshift, Athena engine version 3, Apache Spark on EMR Serverless, and Apache Spark on AWS Glue 5.0, so Approach 2 is not limited to Athena. Each engine reads its own SQL dialect, though, so a view created from Athena needs a Redshift-dialect definition added with `ALTER VIEW` before Redshift can read it. Only Approach 3 carries a hard single-engine restriction, because `invoker_principal()` exists nowhere but Athena.
+
+### Cost considerations
+
+The approaches divide on when the masking runs, and that decides which side of the bill it lands on.
+
+Approach 1 masks once per ETL run and stores the result. The recurring cost is Glue job time plus storage, both scaling with the size of the dataset and how often the pipeline runs, not with how often anyone queries. Readers pay nothing: a masked column is an ordinary materialized column. Between its two variants, masked columns in the same table add one column per masked column, while a separate masked table duplicates every row and every public column alongside them, so the separate table costs more to store and more Glue time to write for the same rules.
+
+Approaches 2 and 3 store nothing and run no pipeline, so they have no write-side cost at all. They move it to read time. A masking view evaluates its masking expressions on the rows each query returns. Adding an entitlement table puts a join and an `invoker_principal()` call on top of that, so Approach 3 is the most expensive of the three per query. On engines billed by data scanned, the join adds the entitlement table to the scan; on engines billed by compute time, the per-row branching adds to it. Either way the cost repeats per query, scaling with read volume rather than data volume.
+
+Which is cheaper depends on the ratio between the two. A large table queried a few times a day favours a view, since precomputing masked copies of data nobody reads is waste. A table under constant dashboard load favours precomputing, because paying once per ETL run beats paying on every dashboard refresh. Keeping an entitlement table small enough for the engine to broadcast it limits the join cost in Approach 3, but does not remove the per-row evaluation.
+
+Measure this against your own workload before committing. Nothing here substitutes for running the query pattern you actually have against a table the size you actually have.
+
+## Choosing an approach
+
+**Start with Approach 2, the masking view.** It reaches the masked outcome with no pipeline, no duplicated data, and no staleness window, and it works on every engine that can read a Data Catalog view. The other two earn their place only against a specific requirement it cannot meet.
+
+Use **Approach 3** when the masking has to vary by caller: several principals reading one view with different rights, or entitlements that change often enough that editing a table beats issuing a grant. It is also the only approach that leaves existing consumers untouched, since every persona queries the same object and the masking changes underneath them, which matters when there are more dashboards and saved queries than you can realistically track down. The price is that readers must be on Athena, plus a join on every query and an entitlement table that is itself an access-control policy to protect.
+
+Use **Approach 1** when precomputing is what you need, in any of these cases:
+
+- Consumers run on engines that cannot read a Data Catalog view, or you would rather not maintain a view definition per SQL dialect.
+- The read volume is high enough that paying per query costs more than paying per ETL run.
+- The masking is expensive to compute, or cannot be expressed in the engine's built-in functions, since Data Catalog views do not support UDFs.
+- A pipeline is already producing this table, and adding masked columns to it costs nothing extra.
+
+Within Approach 1, choose the same-table variant when a downstream tool is pinned to one table name, and the separate-table variant when you want one query definition to work for both personas.
+
+Read the implementation pages for the mechanics of each:
+
+- [Precomputed masking with Glue ETL](precomputed-masking.md), covering both variants, the PySpark transforms, and the LF-Tag and grant design for Approach 1.
+- [Masking view](masking-view.md), covering the view definition, definer semantics, and multi-engine dialects for Approach 2.
+- [Masking view with an entitlement table](glue-views-entitlement-table.md), covering `invoker_principal()` and the entitlement table for Approach 3.
+
+## The shared example
+
+All three implementation pages use the same fictitious table and the same two personas, so the mechanics of each approach can be compared against a fixed baseline.
+
+Table `customers` in database `sales`:
+
+| Column | Classification |
+|---|---|
+| `customer_id` | Public |
+| `name` | PII |
+| `email` | PII |
+| `ssn` | PII |
+| `city` | Public |
+| `country` | Public |
+| `loyalty_tier` | Public |
+
+Two IAM roles stand in for personas:
+
+- `DataEngineerRole`, the privileged persona, sees raw PII: the real `name`, `email`, and `ssn` values.
+- `MarketingAnalystRole`, the restricted persona, sees masked values only.
+
+Everything outside those three PII columns is public, and both personas see it unmasked.
+
+Each PII column is masked a different way, so that one worked example covers all three of the masking types described below:
+
+| Column | Masking type | Restricted persona sees |
+|---|---|---|
+| `ssn` | Full redaction | `NULL` (variant: last-4 as `***-**-6789`) |
+| `email` | Partial reveal | `j***@example.com` |
+| `name` | Hashing | `5e88...`, a hex digest |
+
+The rules are identical on every page; the function names are not. Approaches 1 and 2 run in PySpark, where the hash is `sha2(col("name"), 256)`. Approach 3 runs in Athena SQL, which has no `sha2` and needs `to_hex(sha256(to_utf8(name)))` instead. Each page uses the correct form for its engine.
+
+## Masking types
+
+### Full redaction
+
+The value is replaced outright, with `NULL` or a fixed placeholder. Nothing about the original survives, so nothing about it can be inferred. Use it when the consumer needs the column to exist but has no legitimate use for any part of its contents, which is the usual case for a social security number.
+
+A variant keeps a small fragment for operational use, such as `***-**-6789`, so a support agent can confirm which record they are looking at without reading the whole number. That fragment is real data, so treat the variant as a deliberate partial disclosure rather than as redaction.
+
+### Partial reveal
+
+Enough of the value survives to be useful, and the rest is withheld. `jane.doe@example.com` becomes `j***@example.com`, which is enough for an agent to recognize an address a customer reads out, and not enough to contact them. Phone numbers are commonly handled the same way, keeping the last four digits.
+
+Partial reveal leaks by design, and how much it leaks depends on the data. One character of an email local part is weak evidence; a full birth year, or the last four digits of a number issued sequentially, can be strong evidence when combined with the public columns sitting next to it. Decide what the retained fragment is for before choosing how much to retain.
+
+### Hashing
+
+The value is replaced with a deterministic digest, such as SHA-256 over the raw bytes. The same input always produces the same output, so joins, `GROUP BY`, and distinct counts over the masked column keep returning correct results even though no reader can recover a name from it. That property is what makes hashing the right choice for `name` in the shared example: the analyst can count customers per country without learning who they are.
+
+Hashing a low-cardinality or guessable column provides less protection than it appears to. An unsalted digest of a value drawn from a small set can be reversed by hashing every candidate and comparing, so a hashed `country` column protects nothing. Hashing is appropriate for high-cardinality values, and a salt shared across the pipeline raises the cost of that attack on the rest.
+
+### Encryption and tokenization are out of scope
+
+Encryption and tokenization also substitute a value, and unlike hashing they are meant to be reversible: a privileged consumer is supposed to be able to recover the original, given a key or a lookup in a token vault. That reverse path is what puts them outside these three patterns.
+
+Recovering the value at query time means calling a decryption or detokenization function inside the query, which means a user-defined function. Data Catalog views do not support UDFs in the view definition, so Approach 3 cannot express the reverse direction at all. Approaches 1 and 2 could store an encrypted column instead of a masked one, but the privileged persona would then need the UDF and the key in whatever engine it queries from, and every consumer holding both is a consumer that can produce plaintext. At that point the control is key management rather than Lake Formation permissions, and the masking patterns here stop being the mechanism that protects the data.
+
+If reversible protection is the requirement, treat it as an encryption design and keep Lake Formation grants for deciding who reaches the ciphertext.
+
+### Masking versus dropping the column
+
+Lake Formation already does something adjacent to masking natively: a column-level grant or LF-Tag policy that omits `ssn` removes it from the result set entirely. The caller cannot read the column, reference it in a `WHERE` clause, or see a placeholder where it used to be.
+
+The two behave differently for consumers, which is what makes the choice between them a real one. Column exclusion changes the result schema, so a query or dashboard referencing `ssn` fails, because there is no such column to reference. Masking preserves the schema and changes only the values, so the same query keeps running and `ssn` keeps appearing, holding a value the reader is allowed to see.
+
+Column exclusion needs no pipeline, no view, and no extra grants, so prefer it when the restricted consumer has no need for the column in any form. Masking earns its cost when the consumer needs the column to exist: when a downstream tool expects a fixed schema, when the masked value has to join or aggregate correctly, or when a partial fragment of the original is genuinely useful.

--- a/content/advanced-access-control-patterns/data-masking/precomputed-masking.md
+++ b/content/advanced-access-control-patterns/data-masking/precomputed-masking.md
@@ -1,0 +1,194 @@
+# Precomputed Masking with Glue ETL
+
+This page covers Approach 1 from the [data masking overview](overview.md): a Glue ETL job computes the masked values ahead of time and stores them, and Lake Formation grants decide which stored copy each persona reads.
+
+Two designs share that description, and they differ only in where the masked values land:
+
+- **Masked columns in the same table.** The job adds `name_masked`, `email_masked`, and `ssn_masked` alongside the raw columns. Column-level LF-Tag grants split the two sets between personas.
+- **A separate masked table.** The job writes a second table carrying the same column names with the sensitive values replaced. Table-level grants point each persona at one table or the other.
+
+The masking logic is identical in both, and so is the cost profile: pay once per ETL run, store the result, and readers pay nothing at query time. Pick between them on how consumers query the data. If a downstream tool is pinned to one table name, use the same-table variant. If you want one query definition to work for both personas, use the separate-table variant.
+
+Both designs precompute, which is what separates this approach from the two view-based ones. If you would rather not run a pipeline or store a second copy of anything, read [Masking view](masking-view.md) first; it reaches the same outcome with no ETL.
+
+Both variants change the name a consumer has to query: the same-table variant asks the restricted persona to select `ssn_masked` instead of `ssn`, and the separate-table variant asks it to select from `sales_masked.customers` instead of `sales.customers`. Neither is transparent to anything already reading the raw table. Every affected query, dashboard, saved search, BI dataset, and downstream job has to be found and edited before the restricted persona can use it.
+
+## Variant A: masked columns in the same table
+
+The job reads the seven-column `customers` table from the overview and writes back ten columns:
+
+`customer_id`, `name`, `name_masked`, `email`, `email_masked`, `ssn`, `ssn_masked`, `city`, `country`, `loyalty_tier`
+
+Every sensitive column gains a masked twin beside it. The public columns (`customer_id`, `city`, `country`, `loyalty_tier`) are untouched and unduplicated.
+
+Pick one naming scheme for the twin and use it everywhere, without exception. This page uses a `_masked` suffix, but the convention matters less than its consistency: grant automation and consumer tooling derive the masked name from the raw name programmatically, so a single column that breaks the pattern, `ssn_redacted` instead of `ssn_masked`, forces every downstream script to special-case it.
+
+### Glue ETL job
+
+The job below applies the shared masking rules from the overview: SHA-256 for `name`, partial reveal for `email`, full redaction for `ssn`.
+
+```python
+from pyspark.sql.functions import col, concat, lit, sha2, split
+
+masked = (
+    customers
+    .withColumn("name_masked", sha2(col("name"), 256))
+    .withColumn(
+        "email_masked",
+        concat(
+            split(col("email"), "@").getItem(0).substr(1, 1),
+            lit("***@"),
+            split(col("email"), "@").getItem(1),
+        ),
+    )
+    .withColumn("ssn_masked", lit(None).cast("string"))
+)
+```
+
+`ssn_masked` is written as `NULL`, which is full redaction. For the last-4 variant (`***-**-6789`), replace that line with:
+
+```python
+.withColumn("ssn_masked", concat(lit("***-**-"), col("ssn").substr(-4, 4)))
+```
+
+Write `masked` back to the `customers` table location on each run. The raw columns pass through unchanged; only the three `_masked` columns are computed.
+
+### LF-Tag design
+
+Every column in the table, raw or masked, carries a `Sensitivity` LF-Tag. This is not optional: an LF-Tag expression can only grant on tagged columns, so an untagged column is invisible to a tag-based grant and needs a separate column grant instead. Tagging all ten keeps the table under one grant mechanism.
+
+| Column | `Sensitivity` value |
+|---|---|
+| `customer_id` | `Public` |
+| `city` | `Public` |
+| `country` | `Public` |
+| `loyalty_tier` | `Public` |
+| `name` | `PII` |
+| `email` | `PII` |
+| `ssn` | `PII` |
+| `name_masked` | `Masked` |
+| `email_masked` | `Masked` |
+| `ssn_masked` | `Masked` |
+
+Each persona then gets one LF-Tag expression:
+
+- `MarketingAnalystRole`: `Sensitivity IN (Masked, Public)`, resolving to `customer_id`, `city`, `country`, `loyalty_tier`, `name_masked`, `email_masked`, `ssn_masked`.
+- `DataEngineerRole`: `Sensitivity IN (PII, Public)`, resolving to `customer_id`, `city`, `country`, `loyalty_tier`, `name`, `email`, `ssn`.
+
+Neither expression names a column directly. Adding an eleventh sensitive column later means tagging it `PII` and its twin `Masked`; both grants pick it up untouched.
+
+This call grants `MarketingAnalystRole` its side of the split:
+
+```bash
+aws lakeformation grant-permissions \
+  --principal DataLakePrincipalIdentifier=arn:aws:iam::111122223333:role/MarketingAnalystRole \
+  --permissions "SELECT" \
+  --resource '{
+    "LFTagPolicy": {
+      "CatalogId": "111122223333",
+      "ResourceType": "TABLE",
+      "Expression": [
+        {
+          "TagKey": "Sensitivity",
+          "TagValues": ["Masked", "Public"]
+        }
+      ]
+    }
+  }'
+```
+
+The `DataEngineerRole` grant is the same shape with `TagValues` set to `["PII", "Public"]`.
+
+!!! warning
+
+    Lake Formation computes a principal's effective permissions as the union of every grant that applies to it, LF-Tag expressions and named-resource grants alike. If `MarketingAnalystRole` picks up a second grant carrying `Sensitivity=PII`, whether from a direct column grant, a database-level grant, or a second LF-Tag expression added by someone else later, it sees the raw `ssn`, `email`, and `name` columns in addition to the masked ones. The masking is not weakened in that case, it is void: nothing prevents the underlying value from being read.
+
+    Each persona is correctly configured only when it ends up with exactly one variant of each column. Do not treat issuing the grant above as the end of the job. Check the principal's effective permissions after the grant lands, and re-check whenever another grant touches this table, since the union rule means a grant issued for an unrelated reason can reopen access this design was built to close.
+
+### What consumers see
+
+The two personas read different column sets from the same table, so a query written for one does not run for the other. A dashboard selecting `ssn_masked` fails for `DataEngineerRole`, which has no grant on that column; a dashboard selecting `ssn` fails for the analyst the same way. Neither persona sees all ten columns from `SELECT *`: each gets seven, the four public columns plus its own variant of the three sensitive ones. Two roles running the identical query against the identical table get result sets of the same width and different content, which catches people off guard the first time they compare notes.
+
+## Variant B: a separate masked table
+
+`sales.customers` keeps its seven columns untouched and is granted to `DataEngineerRole` only. A second table carries the same seven column names with `name`, `email`, and `ssn` masked, granted to `MarketingAnalystRole` only. Column names do not change between the two tables; only the values in three of them differ.
+
+Where the second table lives is the one open decision:
+
+- A separate database, `sales_masked`, makes the grant boundary obvious: a grant on the `sales` database or the `sales.customers` table cannot leak into `sales_masked`, and `MarketingAnalystRole` never sees `sales.customers` when it lists tables. The cost is another database to create, tag, and track.
+- Both tables in one database, `sales.customers` and `sales.customers_masked`, is fewer objects to manage. The cost is that anyone who can list tables in `sales` sees the raw and masked names side by side, which invites someone to query the wrong one.
+
+The rest of this section uses `sales_masked.customers`.
+
+### Glue ETL job
+
+The masked values overwrite the columns in place, so this job is shorter than Variant A's: no suffix, no extra columns, the same seven columns written to a different table.
+
+```python
+from pyspark.sql.functions import col, concat, lit, sha2, split
+
+masked = (
+    customers
+    .withColumn("name", sha2(col("name"), 256))
+    .withColumn(
+        "email",
+        concat(
+            split(col("email"), "@").getItem(0).substr(1, 1),
+            lit("***@"),
+            split(col("email"), "@").getItem(1),
+        ),
+    )
+    .withColumn("ssn", lit(None).cast("string"))
+)
+masked.write.mode("overwrite").saveAsTable("sales_masked.customers")
+```
+
+`customers` is the raw `sales.customers` DataFrame read at the start of the job. Nothing in the transform depends on which database the output lands in; the choice above only affects the `saveAsTable` argument.
+
+### Grants
+
+Both grants are table-level `SELECT` with no column lists. `DataEngineerRole` gets `sales.customers`; `MarketingAnalystRole` gets `sales_masked.customers`. There is no column set to keep in sync with a tag scheme, which makes this the easiest of the designs on this page to audit: read the two grants and you know who sees what.
+
+```bash
+aws lakeformation grant-permissions \
+  --principal DataLakePrincipalIdentifier=arn:aws:iam::111122223333:role/MarketingAnalystRole \
+  --permissions "SELECT" \
+  --resource '{"Table": {"CatalogId": "111122223333", "DatabaseName": "sales_masked", "Name": "customers"}}'
+```
+
+An LF-Tag variant scales better past the first table pair. Tag each table itself, not its columns, with `Sensitivity=PII` or `Sensitivity=Masked`, and grant the tag expression instead of naming each table:
+
+```json
+{"LFTagPolicy": {"CatalogId": "111122223333", "ResourceType": "TABLE", "Expression": [{"TagKey": "Sensitivity", "TagValues": ["Masked"]}]}}
+```
+
+A new raw/masked pair then needs one tag assignment on each table rather than two new named-resource grants.
+
+### One query definition serves both personas
+
+Because the column names are identical, a query written against `sales.customers` runs against `sales_masked.customers` unchanged. A BI tool's saved query or a parameterized ETL step points at one table or the other by swapping the database name; the `SELECT` list, joins, and column references stay as they are.
+
+That is the advantage over Variant A, where the two personas see different column sets and a single query cannot serve both.
+
+!!! warning
+
+    The masked table only protects data that cannot also be read from the raw one. If `MarketingAnalystRole` ends up with read access to `sales.customers`, whether through a leftover grant nobody revoked, a database-level grant on `sales` that predates the split, or `IAMAllowedPrincipals` left enabled on the table, the masked copy accomplishes nothing: the analyst queries the raw table instead. Check the effective permissions on `sales.customers` whenever this design is in place, not only on `sales_masked.customers`.
+
+## Cost and performance
+
+Both variants compute the masking once per ETL run and store the result, so readers pay nothing for it. A masked column is a materialized column like any other, and a query selecting it scans exactly as a query against the raw column would.
+
+The recurring cost is Glue job time plus storage, and it scales with the dataset and the pipeline schedule rather than with query volume. The two variants differ in how much of each:
+
+- Variant A adds one column per masked column, and the job computes only those columns.
+- Variant B duplicates every row and every public column alongside the masked ones, so it stores more and its job runtime scales with the full row count rather than with the three columns being masked.
+
+That is the opposite profile from the two view-based approaches, which store nothing and pay at read time instead. A table queried constantly favours precomputing; a large table queried rarely does not.
+
+## Trade-offs
+
+Precomputed masking works on any engine that honors Lake Formation grants, because the mechanism is ordinary column-level or table-level grants rather than anything engine-specific. Nothing about it depends on a view, a SQL dialect, or a caller-identity function.
+
+The costs are a pipeline and a stored second copy, in columns or in a whole table. Freshness is bounded by the last successful run, and in Variant B a lagging job means the analyst reads stale data while the engineer reads fresh data, silently, since nothing about a successful `SELECT` indicates how far behind a table is. Both variants also multiply with sensitivity levels: N levels means N column sets or N tables, each with its own grant and its own freshness check.
+
+Neither variant masks per user. A persona sees the raw set or the masked set, decided by a grant. If entitlements need to vary per principal without a grant change, use [Masking view with an entitlement table](glue-views-entitlement-table.md) instead.

--- a/content/advanced-access-control-patterns/overview.md
+++ b/content/advanced-access-control-patterns/overview.md
@@ -1,0 +1,7 @@
+# Advanced Access Control Patterns
+
+Lake Formation natively enforces access control at the database, table, and column level, through grants, LF-Tags, and row and cell filters. Most authorization requirements fit within that set. Some do not: masking that varies by consuming role, redaction tied to external attributes, or transformations the filter model cannot express.
+
+This section collects patterns for that remainder. Each one composes native Lake Formation features with Glue ETL jobs and Glue Data Catalog views to reach the access-control behavior a requirement demands. 
+
+The first pattern here is [Data Masking](data-masking/overview.md), which covers three ways to return masked values: precomputed by a Glue ETL job and split by Lake Formation grants, applied by a Data Catalog view at query time, or applied per caller by a view that joins an entitlement table.

--- a/content/index.md
+++ b/content/index.md
@@ -8,3 +8,4 @@ This guide is broken down in topics:
 - [Best Practices when using Lake Formations data sharing feature](data-sharing/overview.md)
 - [Best Practices when using LF-Tags](lf-tags/overview.md)
 - [Best Practices for auditing data access in Lake Formation](auditing/overview.md)
+- [Patterns for access control requirements Lake Formation does not natively support](advanced-access-control-patterns/overview.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,13 @@ nav:
     - 'Best Practices': 'lf-tags/best-practices.md'
     - 'Example Usecase': 'lf-tags/example-usecase.md'
     - 'Limitations': 'lf-tags/limitations.md'
+  - 'Advanced Access Control Patterns':
+    - 'Overview': 'advanced-access-control-patterns/overview.md'
+    - 'Data Masking':
+      - 'Overview': 'advanced-access-control-patterns/data-masking/overview.md'
+      - 'Precomputed Masking with Glue ETL': 'advanced-access-control-patterns/data-masking/precomputed-masking.md'
+      - 'Masking View': 'advanced-access-control-patterns/data-masking/masking-view.md'
+      - 'Masking View with an Entitlement Table': 'advanced-access-control-patterns/data-masking/glue-views-entitlement-table.md'
   - 'Auditing':
     - 'Overview': 'auditing/overview.md'
     - 'Lake Formation CloudTrail Events': 'auditing/lake-formation-cloudtrail.md'


### PR DESCRIPTION
Add new page covering Approach 3 from the data masking overview, which extends the masking view pattern with an entitlement table keyed on caller identity via invoker_principal(). Documents the three roles (Admin, Definer, Invoker), entitlement table schema, view SQL definition, and Lake Formation permission setup for dynamic per-principal column masking using Data Catalog views.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
